### PR TITLE
Documentation configuration

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==3.4.3
+sphinx-rtd-theme==0.5.1

--- a/doc/source/404.rst
+++ b/doc/source/404.rst
@@ -1,0 +1,8 @@
+========
+Beartype
+========
+Oops! The page you are looking for was not found.
+Maybe you'll find what you're looking for by searching the documentation
+or returning to the `home page <rtd_>`_.
+
+.. _rtd: https://beartype.rtfd.org

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -76,6 +76,9 @@ extensions = [
     # each of this project's Python modules and linking external references to
     # those modules to these listings.
     'sphinx.ext.viewcode',
+
+    # 3rd party Read The Docs HTML theme for neat and mobile-friendly doc site
+    'sphinx_rtd_theme',
 ]
 
 # ....................{ EXTENSIONS ~ napoleon             }....................
@@ -95,7 +98,7 @@ napoleon_google_docstring = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
From #8: Here's a suggestion for RTD+Sphinx configuration.

RTD can be set up without any further configuration files from their UI. Would you still like it to use the YAML? I think it's simply a matter of preference.

When creating a RTD site, one can import from their GitHub account, or manually set up a site. It could be better if you create the site, and then if I'm needed, I can be added to the project. I'm not sure if manual creation has some drawbacks, but I'd prefer not to test it just to see that it does 😅