### PR TITLE
Add logo to README and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,10 @@
 
 .. # ------------------( SYNOPSIS                           )------------------
 
-==========================================
-beartype —[ the bare-metal type checker ]—
-==========================================
+===============
+|beartype-logo|
+===============
+—[ the bare-metal type checker ]—
 
 |GitHub Actions badge|
 
@@ -2470,6 +2471,10 @@ application stack at tool rather than Python runtime) include:
 * pytype_, published by Google.
 
 .. # ------------------( IMAGES                             )------------------
+.. |beartype-logo| image:: https://raw.githubusercontent.com/beartype/beartype-assets/main/banner/logo-small.png
+   :target: https://beartype.rtfd.org
+   :alt: Beartype logo
+
 .. |GitHub Actions badge| image:: https://github.com/beartype/beartype/workflows/tests/badge.svg
    :target: https://github.com/beartype/beartype/actions?workflow=tests
    :alt: GitHub Actions status

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,7 @@
-==========================================
-beartype —[ the bare-metal type checker ]—
-==========================================
+===============
+|beartype-logo|
+===============
+—[ the bare-metal type checker ]—
 
 .. parsed-literal::
 
@@ -25,3 +26,8 @@ beartype —[ the bare-metal type checker ]—
 
 .. _The Jungle Book:
    https://www.gutenberg.org/files/236/236-h/236-h.htm
+
+.. |beartype-logo| image:: https://raw.githubusercontent.com/beartype/beartype-assets/main/banner/logo.png
+   :width: 510 px
+   :target: https://beartype.rtfd.org
+   :alt: Beartype logo


### PR DESCRIPTION
From #8: This PR adds logos to the mix!

Three things should be taken into account / resolved.
- The slogan is kinda awkward just beneath the logo, but that could be just me.
- On RTD, having the logo as a heading produces a site with no title. Granted, *Beartype* appears right after, but I wish there was a way to either include the title or remove the hyphen.
- Now the links point to RTD. Maybe you'd like PyPI instead, or GitHub -> RTD and RTD -> PyPI? The possibilities are endless and equally confusing for users repeatedly clicking the banner 😄 

![logo example](https://user-images.githubusercontent.com/25202257/105331736-7774ad00-5bdc-11eb-85d1-953c0338fab7.png)
![title example](https://user-images.githubusercontent.com/25202257/105331786-865b5f80-5bdc-11eb-8336-29eaad4a7522.png)

