### PR TITLE
test: Add test cases for `utiltextmunge`

### DIFF
--- a/beartype/_util/text/utiltextmunge.py
+++ b/beartype/_util/text/utiltextmunge.py
@@ -3,19 +3,20 @@
 # Copyright (c) 2014-2021 Cecil Curry.
 # See "LICENSE" for further details.
 
-'''
+"""
 **Beartype string munging utilities** (i.e., callables transforming passed
 strings into new strings with generic string operations).
 
 This private submodule is *not* intended for importation by downstream callers.
-'''
+"""
 
 # ....................{ IMPORTS                           }....................
 from beartype.roar import _BeartypeUtilTextException
 
+
 # ....................{ CASERS                            }....................
 def uppercase_char_first(text: str) -> str:
-    '''
+    """
     Uppercase *only* the first character of the passed string.
 
     Whereas the standard :meth:`str.capitalize` method both uppercases the
@@ -32,15 +33,16 @@ def uppercase_char_first(text: str) -> str:
     ----------
     str
         This string with the first character uppercased.
-    '''
+    """
     assert isinstance(text, str), f'{repr(text)} not string.'
 
     # For great justice!
     return text[0].upper() + text[1:] if text else ''
 
+
 # ....................{ NUMBERERS                         }....................
 def number_lines(text: str) -> str:
-    '''
+    """
     Passed string munged to prefix each line of this string with the 1-based
     number of that line padded by zeroes out to four digits for alignment.
 
@@ -53,7 +55,7 @@ def number_lines(text: str) -> str:
     ----------
     str
         This string with all lines numbered.
-    '''
+    """
     assert isinstance(text, str), f'{repr(text)} not string.'
 
     # For radical benevolence!
@@ -63,10 +65,10 @@ def number_lines(text: str) -> str:
             text.splitlines(), start=1)
     )
 
+
 # ....................{ REPLACERS                         }....................
-#FIXME: Unit test us up, please.
 def replace_str_substrs(text: str, old: str, new: str) -> str:
-    '''
+    """
     Passed string with all instances of the passed source substring globally
     replaced by the passed target substring if this string contains at least
     one such instance *or* raise an exception otherwise (i.e., if this string
@@ -112,7 +114,7 @@ def replace_str_substrs(text: str, old: str, new: str) -> str:
         ...     text='I shot the ALBATROSS.', old='dross', new='drat')
         beartype.roar._BeartypeUtilTextException: String "I shot the
         ALBATROSS." substring "dross" not found.
-    '''
+    """
     assert isinstance(text, str), f'{repr(text)} not string.'
     assert isinstance(old, str), f'{repr(old)} not string.'
     assert isinstance(new, str), f'{repr(new)} not string.'
@@ -128,9 +130,10 @@ def replace_str_substrs(text: str, old: str, new: str) -> str:
     # replaced by this target substring.
     return text.replace(old, new)
 
+
 # ....................{ SUFFIXERS                         }....................
 def suffix_unless_suffixed(text: str, suffix: str) -> str:
-    '''
+    """
     Passed string either suffixed by the passed suffix if this string is not
     yet suffixed by this suffix *or* this string as is otherwise (i.e., if this
     string is already suffixed by this suffix).
@@ -150,7 +153,7 @@ def suffix_unless_suffixed(text: str, suffix: str) -> str:
         * If this string is *not* yet suffixed by this suffix, this string
           suffixed by this suffix.
         * Else, this string as is.
-    '''
+    """
     assert isinstance(text, str), f'{repr(text)} not string.'
     assert isinstance(suffix, str), f'{repr(suffix)} not string.'
 

--- a/beartype/_util/text/utiltextrepr.py
+++ b/beartype/_util/text/utiltextrepr.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2014-2021 Cecil Curry.
 # See "LICENSE" for further details.
 
-'''
+"""
 **Beartype string munging utilities** (i.e., callables transforming passed
 strings into new strings with generic string operations).
 
 This private submodule is *not* intended for importation by downstream callers.
-'''
+"""
 
 # ....................{ IMPORTS                           }....................
 import re
@@ -16,7 +16,7 @@ from string import punctuation
 
 # ....................{ GETTERS                           }....................
 def get_object_representation(obj: object, max_len: int = 76) -> str:
-    '''
+    """
     Pretty-printed quasi-human-readable variant of the string returned by the
     non-pretty-printed machine-readable :meth:`obj.__repr__` dunder method of
     the passed object, truncated to the passed maximum string length.
@@ -62,8 +62,8 @@ def get_object_representation(obj: object, max_len: int = 76) -> str:
     str
         Pretty-printed quasi-human-readable variant of this object's
         non-pretty-printed machine-readable representation.
-    '''
-    assert isinstance(max_len, int), '"{!r}" not an integer.'.format(max_len)
+    """
+    assert isinstance(max_len, int), f'"{max_len}" not an integer.'
 
     # String describing the passed object. For debuggability, the verbose
     # (albeit less human-readable) output of repr() is preferred to the terse
@@ -80,9 +80,7 @@ def get_object_representation(obj: object, max_len: int = 76) -> str:
     # the string returned by this function, double-quote this representation
     # for disambiguity with preceding characters -- notably, sequence indices.
     if obj_repr[0] not in punctuation:
-        #FIXME: Refactor to leverage f-strings after dropping Python 3.5
-        #support, which are the optimal means of performing string formatting.
-        obj_repr = '"{}"'.format(obj_repr)
+        obj_repr = f'"{obj_repr}"'
 
     # If this representation either exceeds this maximum length *OR* contains a
     # newline...

--- a/beartype_test/a00_unit/a00_util/text/test_utiltextmunge.py
+++ b/beartype_test/a00_unit/a00_util/text/test_utiltextmunge.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                           )--------------------
+# Copyright 2014-2021 by Cecil Curry.
+# See "LICENSE" for further details.
+
+"""
+**Beartype replace utility unit tests.**
+
+This submodule unit tests the public API of the private
+:mod:`beartype._util.text.utiltextmunge.py` submodule.
+"""
+
+
+# ....................{ IMPORTS                           }....................
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# WARNING: To raise human-readable test errors, avoid importing from
+# package-specific submodules at module scope.
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# from pytest import raises
+
+# ....................{ TESTS                             }....................
+def test_uppercase_char_first():
+    # Defer heavyweight imports.
+    from pytest import raises
+
+    from beartype._util.text.utiltextmunge import uppercase_char_first
+
+    # Not a string
+    with raises(AssertionError):
+        uppercase_char_first(7)
+
+    assert uppercase_char_first(text='beArTyPe') == "BeArTyPe"
+    assert uppercase_char_first(text="<bear>") == "<bear>"
+    assert uppercase_char_first(text="") == ""
+
+
+def test_number_lines():
+    # Defer heavyweight imports.
+    from pytest import raises
+
+    from beartype._util.text.utiltextmunge import number_lines
+
+    with raises(AssertionError):
+        number_lines(7)
+
+    # No lines to split
+    assert number_lines(text="") == ""
+
+    # This is in essence "x == x" - I don't know if this adds
+    # anything substantive...
+    text = "bears, beats, battlestar galactica\n" * 20
+    expected_result = "\n".join(
+        '(line {:0>4d}) {}'.format(line_no, line_text)
+        for line_no, line_text in enumerate(text.splitlines(), start=1))
+
+    assert number_lines(text) == expected_result
+
+
+def test_replace_str_substrs():
+    # Defer heavyweight imports.
+    from pytest import raises
+
+    from beartype._util.text.utiltextmunge import replace_str_substrs
+    from beartype.roar import _BeartypeUtilTextException
+
+    with raises(AssertionError):
+        replace_str_substrs(text=7, old='Oh No!', new='A non-str value')
+        replace_str_substrs(text='Oh No!', old=7.0, new='is a non-str value')
+        replace_str_substrs(text='Oh No!', old='A non-str value of ', new=7)
+
+    with raises(_BeartypeUtilTextException):
+        replace_str_substrs(text="OG Beartype",
+                            old="I DON'T EXIST!",
+                            new="Therefore I do not think.")
+
+    assert replace_str_substrs(text="I do not think, therefore I am.",
+                               old="do not think",
+                               new="think") == "I think, therefore I am."
+
+
+def test_suffix_unless_suffixed():
+    # Defer heavyweight imports.
+    from pytest import raises
+
+    from beartype._util.text.utiltextmunge import suffix_unless_suffixed
+
+    with raises(AssertionError):
+        suffix_unless_suffixed(text=7, suffix="That's not a string!")
+        suffix_unless_suffixed(text="HEY! You're not a string!", suffix=7)
+
+    not_suffixed_text = "somefile"
+    suffix = ".py"
+    suffixed_text = suffix_unless_suffixed(text=not_suffixed_text, suffix=suffix)
+
+    # Confirm text is suffixed
+    assert suffixed_text == "somefile.py"
+
+    # Attempt to reapply the suffix
+    suffix_unless_suffixed(text=suffixed_text, suffix=suffix)
+
+    # Confirm the text is unchanged
+    assert suffixed_text == "somefile.py"

--- a/beartype_test/a00_unit/a00_util/text/test_utiltextmunge.py
+++ b/beartype_test/a00_unit/a00_util/text/test_utiltextmunge.py
@@ -16,16 +16,15 @@ This submodule unit tests the public API of the private
 # WARNING: To raise human-readable test errors, avoid importing from
 # package-specific submodules at module scope.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# from pytest import raises
+from pytest import raises
 
 # ....................{ TESTS                             }....................
+
+
 def test_uppercase_char_first():
     # Defer heavyweight imports.
-    from pytest import raises
-
     from beartype._util.text.utiltextmunge import uppercase_char_first
 
-    # Not a string
     with raises(AssertionError):
         uppercase_char_first(7)
 
@@ -36,8 +35,7 @@ def test_uppercase_char_first():
 
 def test_number_lines():
     # Defer heavyweight imports.
-    from pytest import raises
-
+    from re import search
     from beartype._util.text.utiltextmunge import number_lines
 
     with raises(AssertionError):
@@ -46,26 +44,35 @@ def test_number_lines():
     # No lines to split
     assert number_lines(text="") == ""
 
-    # This is in essence "x == x" - I don't know if this adds
-    # anything substantive...
-    text = "bears, beats, battlestar galactica\n" * 20
-    expected_result = "\n".join(
-        '(line {:0>4d}) {}'.format(line_no, line_text)
-        for line_no, line_text in enumerate(text.splitlines(), start=1))
+    NEWLINE_COUNT = 20
+    base_string = 'bears, beats, battlestar galactica'
+    total_string = f'{base_string}\n' * NEWLINE_COUNT
 
-    assert number_lines(text) == expected_result
+    numbered_lines_string = number_lines(total_string)
+    numbered_lines_string = numbered_lines_string.splitlines()
+
+    # Confirm the function preserves newlines as is
+    assert len(numbered_lines_string) == NEWLINE_COUNT
+
+    # Confirm the base string is prefixed with something
+    for line_number in range(NEWLINE_COUNT):
+        assert search(pattern=fr'(?<!^){base_string}$',
+                      string=numbered_lines_string[line_number]
+                      ) is not None
 
 
 def test_replace_str_substrs():
     # Defer heavyweight imports.
-    from pytest import raises
-
     from beartype._util.text.utiltextmunge import replace_str_substrs
     from beartype.roar import _BeartypeUtilTextException
 
     with raises(AssertionError):
         replace_str_substrs(text=7, old='Oh No!', new='A non-str value')
+
+    with raises(AssertionError):
         replace_str_substrs(text='Oh No!', old=7.0, new='is a non-str value')
+
+    with raises(AssertionError):
         replace_str_substrs(text='Oh No!', old='A non-str value of ', new=7)
 
     with raises(_BeartypeUtilTextException):
@@ -80,12 +87,12 @@ def test_replace_str_substrs():
 
 def test_suffix_unless_suffixed():
     # Defer heavyweight imports.
-    from pytest import raises
-
     from beartype._util.text.utiltextmunge import suffix_unless_suffixed
 
     with raises(AssertionError):
         suffix_unless_suffixed(text=7, suffix="That's not a string!")
+
+    with raises(AssertionError):
         suffix_unless_suffixed(text="HEY! You're not a string!", suffix=7)
 
     not_suffixed_text = "somefile"


### PR DESCRIPTION
This PR looks to resolve [the issue of not having unit tests for  `utiltextmunge.py`](https://github.com/beartype/beartype/blob/main/beartype/_util/text/utiltextmunge.py#L67). I  ended up adding basic unit tests for all functions in `utiltextmunge.py`.

 I'd specifically like to draw your attention to [this section](https://github.com/beartype/beartype/compare/main...Heliotrop3:dev?expand=1#diff-233a4c754947e50477198537f33a68cbafb4e5265ba2db0503bb48a4764a48b9R49-R56). As per the comment, I am unsure whether this is a worth-while test. Given it's a 1:1 copy of the function's return statement it's given to fail should the function ever change. That being said, it's unsurprisingly also the most compact way of producing the expected result... 


Slipped into this PR is also the resolution of a smaller [refactoring item for `utiltextrepr.py`](https://github.com/beartype/beartype/blob/main/beartype/_util/text/utiltextrepr.py#L83)
