### PR TITLE
Ensure README.rst is decoded as UTF-8 in test_doc_readme on all platforms

### DIFF
--- a/beartype_test/a90_func/doc/test_docreadme.py
+++ b/beartype_test/a90_func/doc/test_docreadme.py
@@ -48,7 +48,7 @@ def test_doc_readme(monkeypatch) -> None:
     from beartype_test.util.path.pytpathproject import get_project_readme_file
 
     # Decoded plaintext contents of this project's readme file as a string.
-    README_CONTENTS = get_project_readme_file().read_text()
+    README_CONTENTS = get_project_readme_file().read_text(encoding='utf-8')
 
     # List of all warning and error messages emitted by "docutils" during
     # parsing of this project's top-level "README.rst" file.


### PR DESCRIPTION
The default platform encoding on Windows is the single-byte encoding cp1252.
This causes an error when reading README.rst in test_doc_readme:

`"UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1495: character maps to <undefined>"`

That is the 3rd byte in the unicode LEFT DOUBLE QUOTATION MARK character from the first code sample in the readme.