### PR TITLE
Fix doortest for py37 py38

### DIFF
--- a/beartype/_util/hint/pep/utilpepget.py
+++ b/beartype/_util/hint/pep/utilpepget.py
@@ -89,10 +89,15 @@ if IS_PYTHON_AT_LEAST_3_9:
 else:
     def get_hint_pep_args(hint: object) -> tuple:
 
-        # Return the value of the "__args__" dunder attribute if this hint
-        # defines this attribute *OR* the empty tuple otherwise.
+        # in python < 3.9, and unparametrized Generic would have the attribute
+        # `_special` set to True (but the actual __args__ are often a TypeVar).
+        # Because we want to differentiate between unparametrized and parametrized
+        # Generics, we check whether the hint is `_special` and if so, we return
+        # the empty tuple (instead of the TypeVar).
         if getattr(hint, '_special', False):
             return ()
+        # Return the value of the "__args__" dunder attribute if this hint
+        # defines this attribute *OR* the empty tuple otherwise.
         return getattr(hint, '__args__', ())
 
 # Document this function regardless of implementation details above.

--- a/beartype/_util/hint/pep/utilpepget.py
+++ b/beartype/_util/hint/pep/utilpepget.py
@@ -91,6 +91,8 @@ else:
 
         # Return the value of the "__args__" dunder attribute if this hint
         # defines this attribute *OR* the empty tuple otherwise.
+        if getattr(hint, '_special', False):
+            return ()
         return getattr(hint, '__args__', ())
 
 # Document this function regardless of implementation details above.

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -77,7 +77,6 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
         Sequence,
         Sized,
         Tuple,
-        TypedDict,
         NamedTuple,
         Union,
     )
@@ -91,11 +90,6 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
     class MuhNutherThing:
         def __len__(self) -> int:
             ...
-
-
-    class MuhDict(TypedDict):
-        thing_one: str
-        thing_two: int
 
 
     class MuhTuple(NamedTuple):
@@ -200,7 +194,6 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
         # moar nestz
         (List[int], Union[str, List[Union[int, str]]], True),
         # not really types:
-        (MuhDict, dict, True),
         (MuhTuple, tuple, True),
     ]
 
@@ -212,12 +205,17 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
         from beartype.typing import (
             Literal,
             Protocol,
+            TypedDict,
         )
 
         # Arbitrary caching @beartype protocol.
         class MuhThingP(Protocol):
             def muh_method(self):
                 ...
+
+        class MuhDict(TypedDict):
+            thing_one: str
+            thing_two: int
 
         # Append cases exercising version-specific relations.
         HINT_SUBHINT_CASES.extend((
@@ -232,6 +230,8 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
             (Literal[7, 8, "3"], Union[list, int], False),
             (int, Literal[7], False),
             (Literal[7, 8], Literal[7, 8, 9], True),
+            # PEP 589-compliant type hints.
+            (MuhDict, dict, True),
         ))
 
         # If the active Python interpreter targets Python >= 3.9 and thus

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -226,12 +226,12 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
             (MuhNutherThing, MuhThingP, False),
             (MuhThingP, MuhThing, False),
             # PEP 586-compliant type hints.
-            (Literal[1], int, True),
+            (Literal[7], int, True),
             (Literal["a"], str, True),
-            (Literal[1, 2, "3"], Union[int, str], True),
-            (Literal[1, 2, "3"], Union[list, int], False),
-            (int, Literal[1], False),
-            (Literal[1, 2], Literal[1, 2, 3], True),
+            (Literal[7, 8, "3"], Union[int, str], True),
+            (Literal[7, 8, "3"], Union[list, int], False),
+            (int, Literal[7], False),
+            (Literal[7, 8], Literal[7, 8, 9], True),
         ))
 
         # If the active Python interpreter targets Python >= 3.9 and thus

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -15,10 +15,6 @@ This submodule unit tests the public API of the public
 # WARNING: To raise human-readable test errors, avoid importing from
 # package-specific submodules at module scope.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-from beartype_test.util.mark.pytskip import (
-    # skip,
-    skip_if_python_version_less_than,
-)
 from pytest import fixture
 
 # ....................{ FIXTURES                           }....................
@@ -340,8 +336,6 @@ def hint_equality_cases() -> 'Iterable[Tuple[object, object, bool]]':
     return tuple(HINT_EQUALITY_CASES)
 
 # ....................{ TESTS ~ testers                    }....................
-#FIXME: Resolve, please. It looks like Python 3.7 and 3.8 are failing hard here.
-@skip_if_python_version_less_than('3.9.0')
 def test_is_subhint(
     hint_subhint_cases: 'Iterable[Tuple[object, object, bool]]') -> None:
     '''
@@ -400,8 +394,6 @@ def test_typehint_new() -> None:
         TypeHint(b'Is there, that from the boundaries of the sky')
 
 
-#FIXME: Resolve, please. It looks like Python 3.7 and 3.8 are failing hard here.
-@skip_if_python_version_less_than('3.9.0')
 def test_typehint_equals(
     hint_equality_cases: 'Iterable[Tuple[object, object, bool]]') -> None:
     '''

--- a/beartype_test/a00_unit/data/hint/pep/proposal/data_pep484.py
+++ b/beartype_test/a00_unit/data/hint/pep/proposal/data_pep484.py
@@ -312,7 +312,7 @@ def add_data(data_module: 'ModuleType') -> None:
     #
     # This boolean is true for Python interpreters targeting 3.6 < Python <
     # 3.9, oddly. (We don't make the rules. We simply complain about them.)
-    _IS_ARGS_HIDDEN = _IS_TYPEVARS_HIDDEN
+    _IS_ARGS_HIDDEN = False
 
     # ..................{ SETS                               }..................
     # Add PEP 484-specific shallowly ignorable test type hints to that set
@@ -1015,7 +1015,7 @@ def add_data(data_module: 'ModuleType') -> None:
             hint=Match,
             pep_sign=HintSignMatch,
             isinstanceable_type=RegexMatchType,
-            is_args=_IS_TYPEVARS_HIDDEN,  # <--- don't ask
+            is_args=_IS_ARGS_HIDDEN,
             is_typevars=_IS_TYPEVARS_HIDDEN,
             piths_meta=(
                 # Regular expression match of one or more string constants.
@@ -1051,7 +1051,7 @@ def add_data(data_module: 'ModuleType') -> None:
             hint=Pattern,
             pep_sign=HintSignPattern,
             isinstanceable_type=RegexCompiledType,
-            is_args=_IS_TYPEVARS_HIDDEN,  # <--- don't ask
+            is_args=_IS_ARGS_HIDDEN,
             is_typevars=_IS_TYPEVARS_HIDDEN,
             piths_meta=(
                 # Regular expression string pattern.


### PR DESCRIPTION
This fixes test_door for python 3.7 and 3.8 by modifying `get_hint_pep_args` to return the empty tuple if the hint is a special generic alias (i.e. has the `_special` attribute set to `True`)

see explanation for why `get_args` was involved here in https://github.com/beartype/beartype/pull/136#issuecomment-1186037251
