### PR TITLE
feat: Support `Generic` and `TypeVar` in `doorcls.TypeHint`

### DIFF
--- a/beartype/door/_doorcls.py
+++ b/beartype/door/_doorcls.py
@@ -1137,7 +1137,13 @@ class _TypeHintUnion(_TypeHintSubscripted):
     def _is_le_branch(self, branch: TypeHint) -> bool:
         raise NotImplementedError('_TypeHintUnion._is_le_branch() unsupported.')  # pragma: no cover
 
+
 class _TypeHintTypeVar(_TypeHintUnion):
+    '''
+    **Partially ordered TypeVar type hint** (i.e., high-level object encapsulating
+    a low-level PEP-compliant TypeVar type hint)
+    '''
+
     _hint: TypeVar
 
     def _wrap_children(self, unordered_children: tuple) -> Tuple["TypeHint", ...]:

--- a/beartype/door/_doorcls.py
+++ b/beartype/door/_doorcls.py
@@ -18,7 +18,6 @@ This private submodule is *not* intended for importation by downstream callers.
 
 # ....................{ IMPORTS                            }....................
 from abc import ABC
-from typing import List, Optional
 from beartype.door._doortest import die_unless_typehint
 from beartype.roar import (
     BeartypeDoorException,
@@ -30,7 +29,7 @@ from beartype.typing import (
     Iterable,
     Tuple,
     Type,
-    TypeVar
+    TypeVar,
 )
 from beartype._data.hint.pep.sign.datapepsigncls import HintSign
 from beartype._data.hint.pep.sign.datapepsignset import (
@@ -617,11 +616,13 @@ class _TypeHintClass(TypeHint):
         return True
 
     def _is_le_branch(self, branch: TypeHint) -> bool:
+        # everything is a subclass of Any
         if branch._origin is Any:
-            # everything is a subclass of Any
             return True
         elif self._origin is Any:
-            # but Any is only a subclass of Any 
+            # but Any is only a subclass of Any.
+            # Furthermore, typing.Any is not suitable as the first
+            # argument to issubclass() below.
             return False
 
         #FIXME: Actually, let's avoid the implicit numeric tower for now.

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -487,7 +487,7 @@ def test_typehint_is_ignorable() -> None:
 
     # Defer heavyweight imports.
     from beartype.door import TypeHint
-    from beartype.roar import BeartypeDoorNonpepException, BeartypeDecorException
+    from beartype.roar import BeartypeDoorException, BeartypeDoorNonpepException
     from beartype_test.a00_unit.data.hint.data_hint import HINTS_IGNORABLE
     from beartype_test.a00_unit.data.hint.pep.data_pep import HINTS_PEP_META
     from contextlib import suppress
@@ -508,7 +508,7 @@ def test_typehint_is_ignorable() -> None:
         #most of these will be BeartypeDoorNonpepException, but there are some
         #covariant type hints (e.g. numpy.dtype[+ScalarType]) that will raise a
         #"not invariant" exception in the TypeVarTypeHint.
-        with suppress(BeartypeDecorException):
+        with suppress(BeartypeDoorException):
             assert TypeHint(hint_pep_meta.hint).is_ignorable is (
                 hint_pep_meta.is_ignorable)
 

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -487,7 +487,7 @@ def test_typehint_is_ignorable() -> None:
 
     # Defer heavyweight imports.
     from beartype.door import TypeHint
-    from beartype.roar import BeartypeDoorNonpepException
+    from beartype.roar import BeartypeDoorNonpepException, BeartypeDecorException
     from beartype_test.a00_unit.data.hint.data_hint import HINTS_IGNORABLE
     from beartype_test.a00_unit.data.hint.pep.data_pep import HINTS_PEP_META
     from contextlib import suppress
@@ -505,7 +505,10 @@ def test_typehint_is_ignorable() -> None:
     for hint_pep_meta in HINTS_PEP_META:
         #FIXME: Remove this suppression *AFTER* improving "TypeHint" to support
         #all currently unsupported type hints.
-        with suppress(BeartypeDoorNonpepException):
+        #most of these will be BeartypeDoorNonpepException, but there are some
+        #covariant type hints (e.g. numpy.dtype[+ScalarType]) that will raise a
+        #"not invariant" exception in the TypeVarTypeHint.
+        with suppress(BeartypeDecorException):
             assert TypeHint(hint_pep_meta.hint).is_ignorable is (
                 hint_pep_meta.is_ignorable)
 

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -80,6 +80,7 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
         Sequence,
         Sized,
         Tuple,
+        Type,
         TypeVar,
         Union,
     )

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -127,6 +127,8 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
         (Any, Any, True),
         (MuhThing, Any, True),
         (Union[int, MuhThing], Any, True),
+        # but Any is only a subtype of Any
+        (Any, object, False),
         # Blame Guido.
         (bool, int, True),
         # PEP 484-compliant implicit numeric tower, which we explicitly and

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -385,17 +385,11 @@ def test_is_subhint(
     '''
 
     # Defer heavyweight imports.
-    from beartype.door import is_subhint, TypeHint
+    from beartype.door import is_subhint
 
     # For each subhint relation to be tested...
     for subhint, superhint, IS_SUBHINT in hint_subhint_cases:
         # Assert this tester returns the expected boolean for these hints.
-        # The second API is equivalent to the first API, (and should be preferred)
-        # but this one is easier to debug on failure.
-        th1 = TypeHint(subhint)
-        th2 = TypeHint(superhint)
-        assert th1.is_subhint(th2) is IS_SUBHINT
-        # same as above, but much cleaner
         assert is_subhint(subhint, superhint) is IS_SUBHINT
 
 # ....................{ TESTS ~ class : dunders            }....................

--- a/tox.ini
+++ b/tox.ini
@@ -256,7 +256,9 @@ extras =
 # dependencies (i.e., third-party packages) required to test this project.
 #
 # Note that this also requires "test-tox" to be listed as an extra above.
-deps = .[test-tox]
+deps = 
+    .[test-tox]
+    pdbpp
 
 # ....................{ ENV ~ commands                    }....................
 # Shell command with which to install project dependencies.

--- a/tox.ini
+++ b/tox.ini
@@ -256,9 +256,7 @@ extras =
 # dependencies (i.e., third-party packages) required to test this project.
 #
 # Note that this also requires "test-tox" to be listed as an extra above.
-deps = 
-    .[test-tox]
-    pdbpp
+deps = .[test-tox]
 
 # ....................{ ENV ~ commands                    }....................
 # Shell command with which to install project dependencies.


### PR DESCRIPTION
This turned out to be easier than I thought!  Please give this a critical look (and perhaps consider any tests that you think I've overlooked).

Turns out treating TypeVar as a special case of `Union` and `Generic` as a plain old `_TypeHintSubscripted` was all that was needed to make a lot of useful test cases now pass.

I _think_ the different between `bounds` and `constraints` in TypeVars really only has meaning for static type checkers, but not so much for the sake of determining "is_subhint" compatibility.  what do you think?

This does not yet tackle covariance and contravariance