### PR TITLE
fix: treat newtype as subtype (not an alias) of it's supertype

### DIFF
--- a/beartype/door/_doorcls.py
+++ b/beartype/door/_doorcls.py
@@ -1114,7 +1114,23 @@ class _TypeHintNewType(_TypeHintClass):
     # relatively fringe case.
     def __init__(self, hint: object) -> None:
         super().__init__(hint)
-        self._origin = get_hint_pep484_newtype_class(hint)
+        supertype = get_hint_pep484_newtype_class(hint)
+        
+        # We want to "create" an origin for this NewType that treats the newtype
+        # as a subclass of its supertype.  For example, if the hint is 
+        # `NewType("MyType", str)`, then the origin should be
+        # `class MyString(str): pass`.
+        try:
+            # we create literal subclass here. but since TypeHints are cached, this
+            # type should only be created once, and therefore work?
+            name = getattr(hint, '__name__', str(hint))
+            self._origin = type(name, (supertype,), {})
+        except TypeError:
+            # not all types are subclassable (like `Any`)
+            self._origin = supertype
+ 
+    def _is_le_branch(self, branch: TypeHint) -> bool:
+        return super()._is_le_branch(branch)
 
 
 

--- a/beartype_test/a00_unit/a60_api/door/test_door.py
+++ b/beartype_test/a00_unit/a60_api/door/test_door.py
@@ -208,8 +208,9 @@ def hint_subhint_cases() -> 'Iterable[Tuple[object, object, bool]]':
         # not really types:
         (MuhTuple, tuple, True),
         # NewType
-        (str, NewStr, True),
         (NewStr, str, True),
+        (NewStr, NewStr, True),
+        (str, NewStr, False),  # NewType act like subtypes
         (NewStr, int, False),
         (int, NewStr, False),
     ]
@@ -371,7 +372,7 @@ def test_is_subhint(
     # For each subhint relation to be tested...
     for subhint, superhint, IS_SUBHINT in hint_subhint_cases:
         # Assert this tester returns the expected boolean for these hints.
-        assert is_subhint(subhint, superhint) is IS_SUBHINT
+        assert is_subhint(subhint, superhint) is IS_SUBHINT, f'{subhint} <= {superhint} is not {IS_SUBHINT}'
 
 # ....................{ TESTS ~ class : dunders            }....................
 def test_typehint_new() -> None:


### PR DESCRIPTION
implements https://github.com/beartype/beartype/pull/148#issuecomment-1189450220

what do you think @leycec?  is it safe to do it this way using `type(...)?`  i figured since `TypeHints` are cached, it should work?

