### PR TITLE
Fix CI not running

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -155,10 +155,10 @@ jobs:
           #FIXME: Reduce to simply "3.11" after Python 3.11 goes live.
           # - tox-env: py311-coverage
           #   python-version: "3.11.0-alpha - 3.11.0"
-          - tox-env: pypy37-coverage
-            python-version: "pypy-3.7"
-          - tox-env: pypy38-coverage
-            python-version: "pypy-3.8"
+          #- tox-env: pypy37-coverage
+          #  python-version: "pypy-3.7"
+          #- tox-env: pypy38-coverage
+          #  python-version: "pypy-3.8"
           #FIXME: Uncomment after PyPy 3.9 goes live.
           # - tox-env: pypy39-coverage
           #   python-version: "pypy-3.9"


### PR DESCRIPTION
I noticed that the Github Actions have been failing for the last couple days:

![image](https://user-images.githubusercontent.com/39638017/183542744-576f9dc8-a778-446a-a58e-402c317c6598.png)

When you click on the ones that are failing right way, they are saying:

```
Error when evaluating 'runs-on' for job 'tests'. .github/workflows/python_test.yml (Line: 171, Col: 14): Unexpected type of value '', expected type: OneOf.
```

Basically, the `include` line(s) are adding metadata to an existing matrix job (based on the key `pypy37-coverage`), but since the key is not specified in the `tox-env` list above, it creates a new, blank (!!) matrix job, hence why `${{ matrix.platform }}` is empty.