### PR TITLE
Expose beartype's `__all__`

### DIFF
--- a/beartype/__init__.py
+++ b/beartype/__init__.py
@@ -91,13 +91,13 @@ For PEP 8 compliance, this specifier has the canonical name
 '''
 
 
-# __all__ = [
-#     'BeartypeConf',
-#     'BeartypeStrategy',
-#     'beartype',
-#     '__version__',
-#     '__version_info__',
-# ]
+__all__ = [
+    'BeartypeConf',
+    'BeartypeStrategy',
+    'beartype',
+    '__version__',
+    '__version_info__',
+]
 '''
 Special list global of the unqualified names of all public package attributes
 explicitly exported by and thus safely importable from this package.


### PR DESCRIPTION
Mypy is unhappy because beartype isn't explicitly specifying its exported attributes. I assume this is a mistake since this code is not deleted but commented out.

```
error: Module "beartype" does not explicitly export attribute "beartype"; implicit reexport disabled
```