### PR TITLE
Add `mypy.ini` to sdist to fix running tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ include LICENSE
 include MANIFEST.in
 include README.rst
 include conftest.py
+include mypy.ini
 include pytest.ini
 include setup.cfg
 include setup.py


### PR DESCRIPTION
Include `mypy.ini` in sdist archives in order to fix test failure caused by it being missing:

    FAILED ../../../beartype_test/a90_func/pep/test_pep561_static.py::test_pep561_mypy - beartype.roar.BeartypeTestPathException: File "/tmp/beartype/dist/beartype-0.13.1/mypy.ini" not found.