### PR TITLE
Update FAQ to recommend jaxtyping even for PyTorch

### DIFF
--- a/doc/src/_links.rst
+++ b/doc/src/_links.rst
@@ -843,8 +843,6 @@
    https://github.com/google/jaxtyping
 .. _nptyping:
    https://github.com/ramonhagenaars/nptyping
-.. _TorchTyping:
-   https://github.com/patrick-kidger/torchtyping
 
 .. # ------------------( LINKS ~ soft : ide                  )------------------
 .. _PyCharm:

--- a/doc/src/faq.rst
+++ b/doc/src/faq.rst
@@ -557,11 +557,13 @@ we give thanks. If:
 * You don't mind adding an **additional mandatory runtime dependency** to your
   app:
 
-  * Require the `third-party "TorchTyping" package <TorchTyping_>`__.
-  * Annotate callables with type hint factories published by TorchTyping (e.g.,
-    ``TorchTyping.TensorType['{metadata1}', ..., '{metadataN}']``).
+  * Require the `third-party "jaxtyping" package <jaxtyping_>`__. (Yes, really!
+    Despite the now-historical name it also supports PyTorch, and has no JAX
+    dependency.)
+  * Annotate callables with type hint factories published by jaxtyping (e.g.,
+    ``jaxtyping.Float[torch.Tensor, '{metadata1 ... metadataN}']``).
 
-  Beartype fully supports `typed PyTorch tensors <TorchTyping_>`__. Because
+  Beartype fully supports `typed PyTorch tensors <jaxtyping_>`__. Because
   `Google mathematician @patrick-kidger <patrick-kidger_>`__ did all the hard
   work, we didn't have to. Bless your runtime API, @patrick-kidger.
 


### PR DESCRIPTION
I'd actually really recommend jaxtyping for NumPy annotations as well, but that's perhaps mildly controversial, given the existence of `nptyping`, and the official NumPy typing hints. I can do a separate PR for that if desired.