### PR TITLE
Added is_simplified_exception configuration option.

### DIFF
--- a/beartype/_conf/confcls.py
+++ b/beartype/_conf/confcls.py
@@ -82,6 +82,9 @@ class BeartypeConf(object):
     _is_debug : bool
         :data:`True` only if debugging :mod:`beartype`. See also the
         :meth:`__new__` method docstring.
+    _is_simplified_exception : bool
+        :data:`True` to generate TypeError instead of BeartypeCallHintParamViolation
+        or BeartypeCallHintReturnViolation, with a simplified exception message.
     _is_pep484_tower : bool
         :data:`True` only if enabling support for the :pep:`484`-compliant
         implicit numeric tower. See also the :meth:`__new__` method docstring.
@@ -123,6 +126,7 @@ class BeartypeConf(object):
         '_conf_kwargs',
         '_is_color',
         '_is_debug',
+        '_is_simplified_exception',
         '_is_pep484_tower',
         '_is_warning_cls_on_decorator_exception_set',
         '_strategy',
@@ -137,6 +141,7 @@ class BeartypeConf(object):
         _conf_kwargs: Dict[str, object]
         _is_color: Optional[bool]
         _is_debug: bool
+        _is_simplified_exception: bool
         _is_pep484_tower: bool
         _is_warning_cls_on_decorator_exception_set: bool
         _strategy: BeartypeStrategy
@@ -164,6 +169,7 @@ class BeartypeConf(object):
         claw_is_pep526: bool = True,
         is_color: BoolTristateUnpassable = ARG_VALUE_UNPASSED,
         is_debug: bool = False,
+        is_simplified_exception: bool = False,
         is_pep484_tower: bool = False,
         strategy: BeartypeStrategy = BeartypeStrategy.O1,
         warning_cls_on_decorator_exception: Optional[TypeWarning] = (
@@ -314,6 +320,9 @@ class BeartypeConf(object):
               enabling this boolean.
 
             Defaults to :data:`False`.
+        is_simplified_exception : bool, optional
+            :data:`True` to generate TypeError instead of BeartypeCallHintParamViolation
+            or BeartypeCallHintReturnViolation, with a simplified exception message.
         is_pep484_tower : bool, optional
             :data:`True` only if enabling support for the :pep:`484`-compliant
             **implicit numeric tower** (i.e., lossy conversion of integers to
@@ -422,6 +431,7 @@ class BeartypeConf(object):
                 claw_is_pep526,
                 is_color,
                 is_debug,
+                is_simplified_exception,
                 is_pep484_tower,
                 strategy,
                 warning_cls_on_decorator_exception,
@@ -462,6 +472,14 @@ class BeartypeConf(object):
                     f'value {repr(is_debug)} not boolean.'
                 )
             # Else, "is_debug" is a boolean.
+            #
+            # If "is_simplified_exception" is *NOT* a boolean, raise an exception.
+            elif not isinstance(is_simplified_exception, bool):
+                raise BeartypeConfParamException(
+                    f'Beartype configuration parameter "is_simplified_exception" '
+                    f'value {repr(is_simplified_exception)} not boolean.'
+                )
+            # Else, "is_simplified_exception" is a boolean.
             #
             # If "is_pep484_tower" is *NOT* a boolean, raise an exception.
             elif not isinstance(is_pep484_tower, bool):
@@ -527,6 +545,7 @@ class BeartypeConf(object):
             self._claw_is_pep526 = claw_is_pep526
             self._is_color = is_color
             self._is_debug = is_debug
+            self._is_simplified_exception = is_simplified_exception
             self._is_pep484_tower = is_pep484_tower
             self._warning_cls_on_decorator_exception = (
                 warning_cls_on_decorator_exception)
@@ -542,6 +561,7 @@ class BeartypeConf(object):
                 claw_is_pep526=claw_is_pep526,
                 is_color=is_color,
                 is_debug=is_debug,
+                is_simplified_exception=is_simplified_exception,
                 is_pep484_tower=is_pep484_tower,
                 strategy=strategy,
                 warning_cls_on_decorator_exception=(
@@ -646,6 +666,21 @@ class BeartypeConf(object):
         '''
 
         return self._is_debug
+
+
+    @property
+    def is_simplified_exception(self) -> bool:
+        '''
+        :data:`True` to generate TypeError instead of BeartypeCallHintParamViolation
+        or BeartypeCallHintReturnViolation, with a simplified exception message.
+
+        See Also
+        ----------
+        :meth:`__new__`
+            Further details.
+        '''
+
+        return self._is_simplified_exception
 
 
     @property
@@ -777,6 +812,7 @@ class BeartypeConf(object):
             f'claw_is_pep526={repr(self._claw_is_pep526)}'
             f', is_color={repr(self._is_color)}'
             f', is_debug={repr(self._is_debug)}'
+            f', is_simplified_exception={repr(self._is_simplified_exception)}'
             f', is_pep484_tower={repr(self._is_pep484_tower)}'
             f', strategy={repr(self._strategy)}'
             f', warning_cls_on_decorator_exception={repr(self._warning_cls_on_decorator_exception)}'

--- a/beartype/_conf/confcls.py
+++ b/beartype/_conf/confcls.py
@@ -558,7 +558,7 @@ class BeartypeConf(object):
             ):
                 raise BeartypeConfParamException(
                     f'Beartype configuration parameter "violation_verbosity" '
-                    f'value {repr(violation_verbosity)} not int.'
+                    f'value {repr(violation_verbosity)} not int between 1 and 5.'
                 )
             # Else, "violation_verbosity" is an int
             #

--- a/beartype/_decor/error/errormain.py
+++ b/beartype/_decor/error/errormain.py
@@ -79,6 +79,7 @@ from beartype.typing import (
     Dict,
     # NoReturn,
     Optional,
+    Type,
 )
 # from beartype._cave._cavemap import NoneTypeOr
 from beartype._conf.confcls import (
@@ -143,7 +144,7 @@ def get_beartype_violation(
     # Optional parameters.
     cls_stack: TypeStack = None,
     random_int: Optional[int] = None,
-) -> BeartypeCallHintViolation:
+) -> Type[Exception]:
     '''
     Human-readable exception detailing the failure of the parameter with the
     passed name *or* return if this name is the magic string ``return`` of the
@@ -231,10 +232,11 @@ def get_beartype_violation(
 
     Returns
     ----------
-    BeartypeCallHintViolation
+    Exception
         Human-readable exception detailing the failure of this parameter or
         return to satisfy the PEP-compliant type hint annotating this parameter
-        or return value, guaranteed to be an instance of either:
+        or return value. Under default configuration, it is guaranteed to be an instance
+        of either:
 
         * :class:`.BeartypeCallHintParamViolation`, if the object failing to
           satisfy this hint is a parameter.
@@ -279,13 +281,13 @@ def get_beartype_violation(
     # If the name of this parameter is the magic string implying the passed
     # object to be a return value, set the above local variables appropriately.
     if pith_name == ARG_NAME_RETURN:
-        exception_cls = BeartypeCallHintReturnViolation
+        exception_cls = conf.violation_return_type
         exception_prefix = prefix_beartypeable_return_value(
             func=func, return_value=pith_value)
     # Else, the passed object is a parameter. In this case, set the above local
     # variables appropriately.
     else:
-        exception_cls = BeartypeCallHintParamViolation
+        exception_cls = conf.violation_param_type
         exception_prefix = prefix_beartypeable_arg_value(
             func=func, arg_name=pith_name, arg_value=pith_value)
 
@@ -362,27 +364,37 @@ def get_beartype_violation(
 
     # ....................{ EXCEPTION                      }....................
     # Substring prefixing this exception message.
-    exception_message_prefix = (
-        f'{exception_prefix}violates type hint {color_hint(repr(hint))}'
-        if not conf.is_simplified_exception else
-        f'{exception_prefix}was expected to be of type {color_hint(repr(hint))}'
-    )
+    exception_message_prefixes = {
+        1: f'{exception_prefix}was expected to be of type {color_hint(repr(hint))}',
+        2: f'{exception_prefix}was expected to be of type {color_hint(repr(hint))}',
+        3: f'{exception_prefix}violates type hint {color_hint(repr(hint))}',
+        4: f'{exception_prefix}violates type hint {color_hint(repr(hint))}',
+        5: f'{exception_prefix}violates type hint {color_hint(repr(hint))}',
+    }
 
     # If this configuration is *NOT* the default configuration, append the
     # machine-readable representation of this non-default configuration to this
     # exception message for disambiguity and clarity.
-    exception_message_conf = (
-        ''
-        if (conf == BEARTYPE_CONF_DEFAULT) or (conf.is_simplified_exception) else
-        f' under non-default configuration {repr(conf)}'
-    )
+    exception_message_confs = {
+        1: '',
+        2: '',
+        3: '',
+        4: '',
+        5: f' under non-default configuration {repr(conf)}',
+    }
 
-    # Exception message embedding this cause.
+    exception_message_suffixes = {
+        1: '.',
+        2: '.',
+        3: f', as {violation_cause_suffixed}',
+        4: f', as {violation_cause_suffixed}',
+        5: f', as {violation_cause_suffixed}',
+    }
+
     exception_message = (
-        f'{exception_message_prefix}{exception_message_conf}, as '
-        f'{violation_cause_suffixed}'
-    ) if not conf.is_simplified_exception else (
-        f'{exception_message_prefix}{exception_message_conf}.'
+        exception_message_prefixes[conf.violation_verbosity]
+        + exception_message_confs[conf.violation_verbosity]
+        + exception_message_suffixes[conf.violation_verbosity]
     )
 
     #FIXME: Unit test us up, please.
@@ -393,13 +405,13 @@ def get_beartype_violation(
 
     #FIXME: Unit test that the caller receives the expected culprit, please.
     # Exception of the desired class embedding this cause.
-    if not conf.is_simplified_exception:
+    try:
         exception = exception_cls(  # type: ignore[misc]
             message=exception_message,
             culprits=tuple(violation_culprits),
         )
-    else:
-        exception = TypeError(exception_message)
+    except TypeError:  # Standard exceptions do not have arguments. Oooh, this is ugly.
+        exception = exception_cls(exception_message)
 
     # Return this exception to the @beartype-generated type-checking wrapper
     # (which directly calls this function), which will then squelch the


### PR DESCRIPTION
Hi @leycec 

Even if I've been silent during the last months, I have been following beartype since I'm still thinking of using it for my library. And now that you published this https://github.com/beartype/beartype/discussions/299 I had a quick reaction that resemble this:

[silence, theater lights close, Félix enters the stage]

"Oh shit. My own little dirty simili-type checker that does an okay job needs all types to be stringified, and that's why I was using `from __future__ import annotations` everywhere. Now I'm back to square one. $/%"&?|!/. Oh god, I think it's time to adopt beartype and stop thinking about it. But I still have these issues that prevent me from using it: #216 #234"

[crowd applauses]

So I decided to dive a bit and created a new configuration option "is_simplified_exception" that solves both issues.

With is_simplified_exception False (default):
```
BeartypeCallHintParamViolation: Method kineticstoolkit.timeseries.TimeSeries.get_ts_after_time()
parameter time='allo' violates type hint <class 'float'> under non-default configuration 
BeartypeConf(claw_is_pep526=True, is_color=None, is_debug=False, is_simplified_exception=False, 
is_pep484_tower=True, strategy=<BeartypeStrategy.O1: 2>, warning_cls_on_decorator_exception=<class 
'beartype.roar._roarwarn.BeartypeClawDecorWarning'>), as str 'allo' not float or int.
```

Standard reaction: Oh, that seems serious, I think I need to reinstall my python environment.

With is_simplified_exception True:
```
TypeError: Method kineticstoolkit.timeseries.TimeSeries.get_ts_after_time() parameter time='allo'
was expected to be of type <class 'float'>.
```

Standard reaction: Oh, I wrote a string instead of a float. My bad.

To be honest, I really don't know what you will think of this pull request, and I'll be perfectly okay if you decide to do nothing with it. It may serve as a starting point for a solution that is less hacky, in case you do find it hacky. But I think it has value since it doesn't serve the same public. The default is perfect for software developers, and the simplified version would be better for the users of a library.

I'll be very curious to know what you think of it.

One last thing, I didn't edit any docstring. I guess that if you accept this PR, many docstrings will need to be changed since both options don't raise the same exception.