### PR TITLE
Feature 302 done, but not.

### DIFF
--- a/beartype/_check/convert/convreduce.py
+++ b/beartype/_check/convert/convreduce.py
@@ -267,6 +267,10 @@ def _reduce_hint_cached(
         * If the passed hint is reducible, another hint reduced from this hint.
         * Else, this hint as is unmodified.
     '''
+    # If this configuration maps this hint to another hint, do so now.
+    # This one-liner looks ridiculous, but actually works. More
+    # importantly, this is the fastest way to accomplish this. Flex!
+    hint = conf.hint_overrides.get(hint, hint)    
 
     # Sign uniquely identifying this hint if this hint is identifiable *OR*
     # "None" otherwise.

--- a/beartype/_conf/_conffrozendict.py
+++ b/beartype/_conf/_conffrozendict.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2023 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+Beartype frozen dict, used to memoize configuration options such as
+hint_overrides.
+'''
+
+class _BeartypeFrozenDict(dict):
+    '''
+    **Frozen dictionary** (i.e., immutable mapping preserving :math:`O(1)`
+    complexity while prohibiting modification).
+
+    Instances of this dictionary are safely hashable and thus suitable for
+    passing as parameters to memoized callables and classes (e.g., our core
+    :class:`beartype.BeartypeConf` class).
+    '''
+
+    __slots__ = ('_hash',)  # <-- preserve space efficiency. curse you, Python!
+
+    def __init__(self, *args, **kwargs) -> None:
+
+        # Instantiate this immutable dictionary with all passed parameters.
+        super().__init__(*args, **kwargs)
+
+        # Precompute the hash for this immutable dictionary at instantiation
+        # time for both efficiency and safety.
+        frozen_items = frozenset(self.items())  # <-- clever stuff
+        self._hash = hash(frozen_items)  # <---- more clever stuff
+
+
+    def __hash__(self) -> int:
+        return self._hash
+
+
+    def __setitem__(self, key, value) -> None:
+        raise NotImplementedError(
+            f'Immutable dictionary {repr(self)}" '
+            f'key {repr(key)} not settable to {repr(value)}.'
+        )

--- a/beartype/_conf/confcls.py
+++ b/beartype/_conf/confcls.py
@@ -79,7 +79,7 @@ class BeartypeConf(object):
         from the names of all keyword parameters accepted by the :meth:`__new__`
         method to the corresponding values of those parameters in this
         configuration).
-    _hint_overrides : Dict[type, type]
+    _hint_overrides : Dict
         Instructs beartype to evaluate given types as other types. This
         is useful for defining a strict API but accepting a looser runtime
         type evaluation. For instance, calling `def function(param : int)`
@@ -178,7 +178,7 @@ class BeartypeConf(object):
         _claw_is_pep526: bool
         _conf_args: tuple
         _conf_kwargs: Dict[str, object]
-        _hint_overrides: Dict[type, type]
+        _hint_overrides: Dict
         _is_color: Optional[bool]
         _is_debug: bool
         _is_pep484_tower: bool
@@ -209,7 +209,7 @@ class BeartypeConf(object):
         # check_time_max_multiplier: Union[int, None] = 1000,
 
         claw_is_pep526: bool = True,
-        hint_overrides: Dict[type, type] = {},
+        hint_overrides: Dict = {},
         is_color: BoolTristateUnpassable = ARG_VALUE_UNPASSED,
         is_debug: bool = False,
         is_pep484_tower: bool = False,
@@ -311,7 +311,7 @@ class BeartypeConf(object):
             performance-sensitive modules *after* profiling those modules to
             suffer performance regressions under import hooks published by the
             :mod:`beartype.claw` subpackage. Defaults to :data:`True`.
-        hint_overrides : Dict[type, type]
+        hint_overrides : Dict
             A dict that instructs beartype to evaluate given types as other
             types. This is useful for defining a strict API but accepting a
             looser runtime type evaluation. For instance, calling
@@ -536,8 +536,6 @@ class BeartypeConf(object):
             # If "hint_overrides" is *NOT* dict of types:types, raise an exception.
             elif (
                 not isinstance(hint_overrides_as_BeartypeHintOverrides, BeartypeHintOverrides)
-                or not all(isinstance(_, type) for _ in hint_overrides.keys())
-                or not all(isinstance(_, type) for _ in hint_overrides.values())
             ):
                 raise BeartypeConfParamException(
                     f'Beartype configuration parameter "hint_overrides" '
@@ -771,7 +769,7 @@ class BeartypeConf(object):
 
 
     @property
-    def hint_overrides(self) -> Dict[type, type]:
+    def hint_overrides(self) -> Dict:
         '''
         Instructs beartype to evaluate given types as other types. This
         is useful for defining a strict API but accepting a looser runtime

--- a/beartype/_conf/confcls.py
+++ b/beartype/_conf/confcls.py
@@ -79,7 +79,7 @@ class BeartypeConf(object):
         from the names of all keyword parameters accepted by the :meth:`__new__`
         method to the corresponding values of those parameters in this
         configuration).
-    _hint_overrides : BeartypeHintOverrides
+    _hint_overrides : Dict[type, type]
         Instructs beartype to evaluate given types as other types. This
         is useful for defining a strict API but accepting a looser runtime
         type evaluation. For instance, calling `def function(param : int)`
@@ -178,7 +178,7 @@ class BeartypeConf(object):
         _claw_is_pep526: bool
         _conf_args: tuple
         _conf_kwargs: Dict[str, object]
-        _hint_overrides: BeartypeHintOverrides
+        _hint_overrides: Dict[type, type]
         _is_color: Optional[bool]
         _is_debug: bool
         _is_pep484_tower: bool
@@ -209,7 +209,7 @@ class BeartypeConf(object):
         # check_time_max_multiplier: Union[int, None] = 1000,
 
         claw_is_pep526: bool = True,
-        hint_overrides: BeartypeHintOverrides = BeartypeHintOverrides(),
+        hint_overrides: Dict[type, type] = {},
         is_color: BoolTristateUnpassable = ARG_VALUE_UNPASSED,
         is_debug: bool = False,
         is_pep484_tower: bool = False,
@@ -311,7 +311,7 @@ class BeartypeConf(object):
             performance-sensitive modules *after* profiling those modules to
             suffer performance regressions under import hooks published by the
             :mod:`beartype.claw` subpackage. Defaults to :data:`True`.
-        hint_overrides : BeartypeHintOverrides
+        hint_overrides : Dict[type, type]
             A dict that instructs beartype to evaluate given types as other
             types. This is useful for defining a strict API but accepting a
             looser runtime type evaluation. For instance, calling

--- a/beartype/_conf/confcls.py
+++ b/beartype/_conf/confcls.py
@@ -782,7 +782,7 @@ class BeartypeConf(object):
         `numbers.Integrals` as being an `int`.
         '''
         
-        return self._hint_overrides
+        return dict(self._hint_overrides)
 
 
     @property
@@ -978,6 +978,7 @@ class BeartypeConf(object):
         return (
             f'{self.__class__.__name__}('
             f'claw_is_pep526={repr(self._claw_is_pep526)}'
+            f', hint_overrides={repr(self._hint_overrides)}'
             f', is_color={repr(self._is_color)}'
             f', is_debug={repr(self._is_debug)}'
             f', is_pep484_tower={repr(self._is_pep484_tower)}'


### PR DESCRIPTION
Hi @leycec

Feature #302 is done. But not.

Having a dict parameter seems to be problematic because the current code tries to build a hashable tuple of parameters (confcls.py, line 498 of this commit) but a dict is not hashable. Therefore it strongly complains.

Unfortunately I could not do much more work on it, because the whole configuration caching procedure is way out of my understanding. At least I added "stuff" so that the new config parameter now exists and it "should work". 😕

Sorry to throw this back to you!