### PR TITLE
Added the magnificent class BeartypeHintOverrides for generous use by the general user

### DIFF
--- a/beartype/__init__.py
+++ b/beartype/__init__.py
@@ -68,6 +68,9 @@ if 'beartype.__is_installing__' not in _modules:
         BeartypeStrategy as BeartypeStrategy,
         BeartypeViolationVerbosity as BeartypeViolationVerbosity,
     )
+    from beartype._conf._conffrozendict import (
+        _BeartypeFrozenDict as BeartypeTypeOverrides
+    )
 # Else, this submodule is *NOT* being imported at install time.
 
 # Delete the temporarily imported "sys.modules" global for ultimate safety.

--- a/beartype/__init__.py
+++ b/beartype/__init__.py
@@ -69,7 +69,7 @@ if 'beartype.__is_installing__' not in _modules:
         BeartypeViolationVerbosity as BeartypeViolationVerbosity,
     )
     from beartype._conf._conffrozendict import (
-        _BeartypeFrozenDict as BeartypeTypeOverrides
+        _BeartypeFrozenDict as BeartypeHintOverrides
     )
 # Else, this submodule is *NOT* being imported at install time.
 


### PR DESCRIPTION
Hi again @leycec 

The class was not available in the main beartype namespace. I added it so that I can do this code:

```python
from numbers import Integral, Real, Complex
from beartype import (
    beartype,
    BeartypeConf,
    BeartypeViolationVerbosity,
    BeartypeHintOverrides,
)

typecheck = beartype(
    conf=BeartypeConf(
        hint_overrides=BeartypeHintOverrides(
            {int: Integral, float: Real, complex: Complex}
        ),
        violation_param_type=TypeError,
        violation_return_type=TypeError,
        violation_verbosity=BeartypeViolationVerbosity.MINIMUM,
    )
)
```

and use `@typecheck` everywhere I need (I prefer it to the claw at this time, it's more explicit and doesn't suffer from weird half-loaded circular input problems due to partial module reloading when I work both on my package and on beartype in a same eternal IPython session).

and guess what, it...

### WORKS

Everything f..ing WORKS.

I also ran the unit tests this time! Some problems with the very last tests, related with packages that are not installed on my system I think. The printout is at the end of this PR.

# Last thing

Mostly as a note and also to know if you think it's a bad idea. Using numpy.typing.ArrayLike was not generating happy messages, e.g.

```python
Method kineticstoolkit.timeseries.TimeSeries.__init__() parameter time={}
was expected to be of type typing.Union[numpy._typing._array_like.
_SupportsArray[numpy.dtype[typing.Any]],numpy._typing.
_nested_sequence._NestedSequence[numpy._typing._array_like.
_SupportsArray[numpy.dtype[typing.Any]]], bool, int, float, complex, str, bytes, 
numpy._typing._nested_sequence._NestedSequence[typing.Union[
bool, int, float, complex, str, bytes]]]
```

Not what I call a clean output.

So I cheated and did this in a custom private typing_.py module instead:

```python
from typing import NewType, TYPE_CHECKING
from numpy.typing import ArrayLike as npt_ArrayLike

# Define custom types so that beartype, sphinx,
# mypy and the user are all happy
if TYPE_CHECKING:  # mypy is running
    ArrayLike = npt_ArrayLike
else:  # runtime
    ArrayLike = NewType("ArrayLike", npt_ArrayLike)  # mypy cries
```

Now, mypy is still happy, and the same error as above prints like:

```python
TypeError: Method kineticstoolkit.timeseries.TimeSeries.__init__() parameter time={}
was expected to be of type kineticstoolkit.typing_.ArrayLike.
```

which I believe is much more helpful. As THE expert, do you think it's a hack or it's legit to do this? Personally I'm happy with it. Personalizing the string completely would be still better but I don't think its possible.

```python
TypeError: Method kineticstoolkit.timeseries.TimeSeries.__init__() parameter time={}
was expected to be of type ArrayLike.
```

# True last thing

I don't expect a satisfactory answer to this last question, it seems everything and its contrary has been written on it.

I have been able to remove all `from __future__ import annotations` except in one place : a big class where many methods require or return instances of the class itself. I think this is the classic problem.

```python
classdef TheClass:
    def __init__(self, src: TheClass | pd.DataFrame | ArrayLike) -> TheClass
        ...
```

The pre-"from-future-import-annotations" way was to put TheClass in "quotes". But it doesn't work with the "post-from-future-import-annotions" (python 3.9) pipes notation `"TheClass" | pd.DataFrame | ArrayLike`. Do you know of a better way, or I just wait 2-3 years and drop python < 3.12?
