### PR TITLE
add plumbing for `claw_skip_package_names` option

### DIFF
--- a/beartype/_conf/confcls.py
+++ b/beartype/_conf/confcls.py
@@ -38,6 +38,7 @@ from beartype.roar._roarwarn import (
 from beartype.typing import (
     TYPE_CHECKING,
     Dict,
+    Iterable,
     Optional,
 )
 from beartype._conf.confenum import (
@@ -207,6 +208,7 @@ class BeartypeConf(object):
         '_claw_decoration_position_funcs',
         '_claw_decoration_position_types',
         '_claw_is_pep526',
+        '_claw_skip_package_names',
         '_conf_args',
         '_conf_kwargs',
         '_hash',
@@ -234,6 +236,7 @@ class BeartypeConf(object):
         _claw_decoration_position_funcs: BeartypeDecorationPosition
         _claw_decoration_position_types: BeartypeDecorationPosition
         _claw_is_pep526: bool
+        _claw_skip_package_names: Iterable[str]
         _conf_args: tuple
         _conf_kwargs: DictStrToAny
         _hash: int
@@ -277,6 +280,7 @@ class BeartypeConf(object):
         claw_decoration_position_types: BeartypeDecorationPosition = (
             BeartypeDecorationPosition.LAST),
         claw_is_pep526: bool = True,
+        claw_skip_package_names: Iterable[str] = (),
         hint_overrides: BeartypeHintOverrides = BEARTYPE_HINT_OVERRIDES_EMPTY,
         is_color: BoolTristateUnpassable = ARG_VALUE_UNPASSED,
         is_debug: bool = False,
@@ -716,6 +720,7 @@ class BeartypeConf(object):
                 claw_decoration_position_funcs,
                 claw_decoration_position_types,
                 claw_is_pep526,
+                claw_skip_package_names,
                 hint_overrides,
                 is_color,
                 is_debug,
@@ -746,6 +751,7 @@ class BeartypeConf(object):
                 claw_decoration_position_funcs=claw_decoration_position_funcs,
                 claw_decoration_position_types=claw_decoration_position_types,
                 claw_is_pep526=claw_is_pep526,
+                claw_skip_package_names=claw_skip_package_names,
                 hint_overrides=hint_overrides,
                 is_color=is_color,
                 is_debug=is_debug,
@@ -819,6 +825,7 @@ class BeartypeConf(object):
             self._claw_decoration_position_types = conf_kwargs[  # pyright: ignore
                 'claw_decoration_position_types']
             self._claw_is_pep526 = conf_kwargs['claw_is_pep526']  # pyright: ignore
+            self._claw_skip_package_names = conf_kwargs['claw_skip_package_names']  # pyright: ignore
             self._hint_overrides = conf_kwargs['hint_overrides']  # pyright: ignore
             self._is_color = conf_kwargs['is_color']  # pyright: ignore
             self._is_debug = conf_kwargs['is_debug']  # pyright: ignore
@@ -1085,6 +1092,31 @@ class BeartypeConf(object):
         '''
 
         return self._claw_is_pep526
+
+
+    @property
+    def claw_skip_package_names(self) -> Iterable[str]:
+        '''
+        :data:`Iterable[str]` listing package names that are to be skipped
+        during type checking when importing modules under import hooks
+        published by the :mod:`beartype.claw` subpackage.
+
+        This is useful for excluding specific packages from type enforcement,
+        thus optimizing performance or avoiding conflicts with certain
+        packages that may not be compatible with the import hooks.
+
+        This docstring was lovingly hallucinated by ChatGPT, please suggest
+        improvements.
+
+        See Also
+        --------
+        :meth:`__new__`
+            Further details.
+        '''
+
+        return self._claw_skip_package_names
+
+
 
     # ..................{ PROPERTIES ~ options : violation   }..................
     @property

--- a/beartype/_conf/conftest.py
+++ b/beartype/_conf/conftest.py
@@ -35,6 +35,7 @@ from beartype._conf.confoverrides import (
 )
 from beartype._data.hint.datahinttyping import DictStrToAny
 from beartype._util.cls.utilclstest import is_type_subclass
+from collections.abc import Iterable as IterableABC
 
 # ....................{ RAISERS                            }....................
 def die_unless_conf(conf: 'beartype.BeartypeConf') -> None:
@@ -185,6 +186,23 @@ def die_if_conf_kwargs_invalid(conf_kwargs: DictStrToAny) -> None:
         )
     # Else, "warning_cls_on_decorator_exception" is either "None" *OR* a
     # warning category.
+    #
+    # If "claw_skip_package_names" is *NOT* an iterable of strings, raise an
+    # exception.
+    elif not (
+        isinstance(conf_kwargs['claw_skip_package_names'], IterableABC) and
+        all(
+            isinstance(claw_skip_package_name, str)
+            for claw_skip_package_name in conf_kwargs[
+                'claw_skip_package_names']
+        )
+    ):
+        raise BeartypeConfParamException(
+            f'Beartype configuration parameter "claw_skip_package_names" '
+            f'value {repr(conf_kwargs["claw_skip_package_names"])} not '
+            f'iterable of strings.'
+        )
+    # Else, "claw_skip_package_names" is an iterable of strings.
 
     # For the name of each keyword parameter whose value is expected to be an
     # exception subclass...

--- a/beartype_test/a00_unit/a40_api/conf/test_confcls.py
+++ b/beartype_test/a00_unit/a40_api/conf/test_confcls.py
@@ -64,6 +64,7 @@ def test_conf_dataclass() -> None:
         'claw_decoration_position_funcs',
         'claw_decoration_position_types',
         'claw_is_pep526',
+        'claw_skip_package_names',
         'hint_overrides',
         'is_color',
         'is_debug',
@@ -90,6 +91,7 @@ def test_conf_dataclass() -> None:
         claw_decoration_position_funcs=BeartypeDecorationPosition.FIRST,
         claw_decoration_position_types=BeartypeDecorationPosition.FIRST,
         claw_is_pep526=False,
+        claw_skip_package_names = ('a','b','c'),
         hint_overrides=BEAR_HINT_OVERRIDES_NONEMPTY,
         is_color=True,
         is_debug=True,
@@ -130,6 +132,7 @@ def test_conf_dataclass() -> None:
             claw_decoration_position_funcs=BeartypeDecorationPosition.FIRST,
             claw_decoration_position_types=BeartypeDecorationPosition.LAST,
             claw_is_pep526=False,
+            claw_skip_package_names = ('a','b','c'),
             hint_overrides=BEAR_HINT_OVERRIDES_NONEMPTY,
             is_debug=True,
             is_color=True,
@@ -155,6 +158,7 @@ def test_conf_dataclass() -> None:
             is_debug=True,
             hint_overrides=BEAR_HINT_OVERRIDES_NONEMPTY,
             claw_is_pep526=False,
+            claw_skip_package_names = ('a','b','c'),
             claw_decoration_position_types=BeartypeDecorationPosition.LAST,
             claw_decoration_position_funcs=BeartypeDecorationPosition.FIRST,
         )
@@ -167,6 +171,7 @@ def test_conf_dataclass() -> None:
     assert BEAR_CONF_DEFAULT.claw_decoration_position_types is (
         BeartypeDecorationPosition.LAST)
     assert BEAR_CONF_DEFAULT.claw_is_pep526 is True
+    assert BEAR_CONF_DEFAULT.claw_skip_package_names == ()
     assert BEAR_CONF_DEFAULT.hint_overrides is BEARTYPE_HINT_OVERRIDES_EMPTY
     assert BEAR_CONF_DEFAULT.is_color is None
     assert BEAR_CONF_DEFAULT.is_debug is False
@@ -190,6 +195,7 @@ def test_conf_dataclass() -> None:
     assert BEAR_CONF_DEFAULT.claw_decoration_position_types is (
         BeartypeDecorationPosition.LAST)
     assert BEAR_CONF_NONDEFAULT.claw_is_pep526 is False
+    assert BEAR_CONF_DEFAULT.claw_skip_package_names == ()
     assert BEAR_CONF_NONDEFAULT.hint_overrides == (
         BEAR_HINT_OVERRIDES_NONEMPTY | beartype_hint_overrides_pep484_tower())
     assert BEAR_CONF_NONDEFAULT.is_color is True
@@ -291,6 +297,8 @@ def test_conf_dataclass() -> None:
         BeartypeConf(claw_is_pep526=(
             'The fountains mingle with the river'))
     with raises(BeartypeConfParamException):
+        BeartypeConf(claw_skip_package_names=(12345))
+    with raises(BeartypeConfParamException):
         BeartypeConf(hint_overrides=(
             'Wildered, and wan, and panting, she returned.'))
     with raises(BeartypeConfParamException):
@@ -358,6 +366,8 @@ def test_conf_dataclass() -> None:
             BeartypeDecorationPosition.FIRST)
     with raises(AttributeError):
         BEAR_CONF_DEFAULT.claw_is_pep526 = True
+    with raises(AttributeError):
+        BEAR_CONF_DEFAULT.claw_skip_package_names = ('q','w','e')
     with raises(AttributeError):
         BEAR_CONF_DEFAULT.hint_overrides = {}
     with raises(AttributeError):

--- a/tox
+++ b/tox
@@ -12,13 +12,6 @@
 # canonical ${BASH_SOURCE} string global, reliably providing the absolute
 # pathnames of this script and hence this script's directory.
 #
-# --------------------( CAVEATS                            )--------------------
-# *THE HIGHER-LEVEL "tox" SCRIPT SHOULD TYPICALLY BE RUN INSTEAD.* This
-# lower-level script only exercises this project against the single Python
-# interpreter associated with the "pytest" command and is thus suitable *ONLY*
-# as a rapid sanity check. Meanwhile, the higher-level "tox" command exercises
-# this project against all installed Python interpreters and is thus suitable
-# as a full-blown correctness check (e.g., before submitting pull requests).
 
 # ....................{ PREAMBLE                           }....................
 # Enable strictness for sanity.


### PR DESCRIPTION
This is the first of two PRs for https://github.com/beartype/beartype/issues/407

It adds the plumbing for a new `claw_skip_package_names` option. A follow-up will actually implement the feature.