### PR TITLE
Some improvements for Python 3.14 / PEP 649 support

### DIFF
--- a/beartype/_data/hint/pep/datapeprepr.py
+++ b/beartype/_data/hint/pep/datapeprepr.py
@@ -270,6 +270,14 @@ HINT_MODULE_NAME_TO_TYPE_BASENAME_TO_SIGN: Dict[str, DictStrToHintSign] = {
         'str': HintSignForwardRef,
     },
 
+    # ..................{ ANNOTATIONLIB                      }..................
+    # annotation support in Python 3.14+.
+    'annotationlib': {
+        # ..................{ PEP 649/649                    }..................
+        # typing.ForwardRef was moved to annotationlib.
+        'ForwardRef': HintSignForwardRef,
+    },
+
     # ..................{ DATACLASSES                        }..................
     # Standard PEP 557-compliant dataclass module.
     'dataclasses': {

--- a/beartype/_data/module/datamodtyping.py
+++ b/beartype/_data/module/datamodtyping.py
@@ -18,6 +18,8 @@ TYPING_MODULE_NAMES_STANDARD = frozenset((
     'typing',
     # Third-party typing compatibility layer bundled with @beartype itself.
     'beartype.typing',
+    # Contains ForwardRef as of 3.14
+    'annotationlib',
 ))
 '''
 Frozen set of the fully-qualified names of all **standard typing modules**

--- a/beartype/_util/func/utilfuncget.py
+++ b/beartype/_util/func/utilfuncget.py
@@ -21,6 +21,10 @@ from beartype._data.hint.datahinttyping import (
     HintAnnotations,
     TypeException,
 )
+from beartype._util.py.utilpyversion import IS_PYTHON_AT_LEAST_3_14
+
+if IS_PYTHON_AT_LEAST_3_14:
+    from annotationlib import get_annotations, Format
 
 # ....................{ GETTERS ~ descriptors              }....................
 #FIXME: Unit test us up, please.
@@ -207,4 +211,6 @@ def get_func_annotations_or_none(func: Callable) -> Optional[HintAnnotations]:
     #   in general-purpose contexts where this guarantee does *NOT*
     #   necessarily hold, we intentionally access that attribute safely albeit
     #   somewhat more slowly via getattr().
+    if IS_PYTHON_AT_LEAST_3_14:
+        return get_annotations(func, format=Format.FORWARDREF)
     return getattr(func, '__annotations__', None)


### PR DESCRIPTION
It's still very early for Python 3.14, but I decided to try running
beartype's test suite to see how well it works with all the annotations
changes that have landed in CPython.

There were a few test failures for boring reasons (mostly, the fact
that typing.ForwardRef is now in the annotationlib module). I fixed
some but not all of those.

I also tried to make beartype work well with code that relies on
new PEP 649 functionality, such as:

from beartype import beartype

@beartype
def f(x: notyetdefined) -> notyetdefined:
    return x

class notyetdefined:
    pass

f(notyetdefined())
f(1)  # error

To support such code, I made beartype use annotationlib.get_annotations()
with the FORWARDREF format, which appears to work fine.

I will leave this as a draft for now since it's still early in the PEP 649
stage, but I feel this is a promising indicator that it shouldn't be too
hard to adapt beartype to the PEP 649 world.
