### PR TITLE
Remove incorrect `self` argument from `mock_types` example

### DIFF
--- a/doc/src/faq.rst
+++ b/doc/src/faq.rst
@@ -811,7 +811,7 @@ type is an instance of the type it mocks, though?
 
    >>> from beartype import beartype
    >>> @beartype
-   ... def muh_func(self, muh_arg: OriginalType): print('Yolo, bro.')
+   ... def muh_func(muh_arg: OriginalType): print('Yolo, bro.')
    >>> muh_func(MockType())
    Yolo, bro.
 


### PR DESCRIPTION
Without this change, running the example gives:

```
TypeError: muh_func() missing 1 required positional argument: 'muh_arg'
```