### PR TITLE
Avoid static type checking error in mock types FAQ example

### DIFF
--- a/doc/src/faq.rst
+++ b/doc/src/faq.rst
@@ -808,6 +808,9 @@ type is an instance of the type it mocks, though?
    >>> class MockType:
    ...     @property
    ...     def __class__(self) -> type: return OriginalType
+   ...     @__class__.setter
+   ...     def __class__(self, value: type) -> None:
+   ...         super.__class__ = value
 
    >>> from beartype import beartype
    >>> @beartype


### PR DESCRIPTION
If I use the example code without this change, I get the following errors from `mypy` and `pyright`:

```
error: Read-only property cannot override read-write property  [misc]
```

```
error: "__class__" incorrectly overrides property of same name in class "object"
    Property method "fset" is missing in override (reportIncompatibleMethodOverride)
```