### PR TITLE
Fix remaining mypy errors related to TypeForm

### DIFF
--- a/beartype/_check/convert/_convcoerce.py
+++ b/beartype/_check/convert/_convcoerce.py
@@ -188,7 +188,7 @@ def coerce_func_hint_root(
         # thus taken the surprisingly sensible course of silently ignoring this
         # edge case by effectively performing the same type expansion as
         # performed here. *applause*
-        return Union[hint, NotImplementedType]  # pyright: ignore
+        return Union[hint, NotImplementedType]  # type: ignore[return-value]  # pyright: ignore
 
     # Defer to the function-agnostic root hint coercer as a generic fallback.
     return coerce_hint_root(hint=hint, exception_prefix=exception_prefix)

--- a/beartype/_check/convert/_reduce/_nonpep/api/redapinumpy.py
+++ b/beartype/_check/convert/_reduce/_nonpep/api/redapinumpy.py
@@ -241,4 +241,4 @@ def reduce_hint_numpy_ndarray(
     hint_validator.get_repr = repr(hint)
 
     # Return this validator annotating the NumPy array type.
-    return Annotated[ndarray, hint_validator]  # pyright: ignore
+    return Annotated[ndarray, hint_validator]  # type: ignore[return-value]  # pyright: ignore

--- a/beartype/_check/convert/_reduce/_pep/pep484585/redpep484585generic.py
+++ b/beartype/_check/convert/_reduce/_pep/pep484585/redpep484585generic.py
@@ -24,6 +24,8 @@ from beartype._util.hint.pep.proposal.pep544 import (
 )
 from beartype._util.hint.pep.utilpepget import get_hint_pep_origin_or_none
 
+_AnyHint: Hint = Any
+
 # ....................{ REDUCERS                           }....................
 def reduce_hint_pep484585_generic_subscripted(
     hint: Hint, exception_prefix: str, **kwargs) -> HintOrHintSanifiedData:
@@ -87,7 +89,7 @@ def reduce_hint_pep484585_generic_subscripted(
     # originating from "typing" type origins for stability reasons.
     if get_hint_pep_origin_or_none(hint) is Generic:
         # print(f'Testing generic hint {repr(hint)} deep ignorability... True')
-        return Any
+        return _AnyHint
     # Else, this subscripted generic is *NOT* the "typing.Generic" superclass
     # directly parametrized by one or more type variables and thus *NOT* an
     # ignorable non-protocol.

--- a/beartype/_check/convert/_reduce/redhint.py
+++ b/beartype/_check/convert/_reduce/redhint.py
@@ -54,6 +54,8 @@ from beartype._util.kind.map.utilmapfrozen import FrozenDict
 from beartype._util.kind.map.utilmapset import remove_mapping_keys
 from beartype._util.utilobject import SENTINEL
 
+_AnyHint: Hint = Any
+
 # ....................{ REDUCERS                           }....................
 def reduce_hint_child(
     hint: Hint, kwargs: DictStrToAny) -> HintOrHintSanifiedData:
@@ -295,7 +297,7 @@ def reduce_hint(
         # "HintSignUnion". Ergo, this reduction *CANNOT* be trivially
         # implemented as a standard reduction assigned a single sign.
         if hint_repr in HINTS_REPR_IGNORABLE_SHALLOW:
-            return Any  # pyright: ignore
+            return _AnyHint  # pyright: ignore
         # Else, this hint is *NOT* shallowly ignorable.
 
         # ....................{ PHASE ~ override           }....................
@@ -370,7 +372,7 @@ def reduce_hint(
         # Note that this is an optional short-circuiting optimization avoiding
         # multiple repetitious reductions for each ignorable hint.
         if hint is Any:
-            return Any
+            return _AnyHint
         # Else, this hint is currently unignorable. Continue reducing.
 
         # ....................{ PHASE ~ cached             }....................
@@ -385,7 +387,7 @@ def reduce_hint(
         # Note that, unlike the similar test above, this test is required rather
         # than merely an optimization.
         if hint_or_sane is Any:
-            return Any  # pyright: ignore
+            return _AnyHint  # pyright: ignore
         # Else, this hint is currently unignorable. Continue reducing.
         #
         # If the current and previously reduced instances of this hint are

--- a/beartype/_check/forward/fwdresolve.py
+++ b/beartype/_check/forward/fwdresolve.py
@@ -59,7 +59,7 @@ from traceback import format_exc
 #FIXME: Unit test us up, please.
 def resolve_hint(
     # Mandatory parameters.
-    hint: str,
+    hint: Hint,  # is also a str
     decor_meta: BeartypeDecorMeta,
 
     # Optional parameters.

--- a/beartype/_check/metadata/hint/hintsmeta.py
+++ b/beartype/_check/metadata/hint/hintsmeta.py
@@ -53,6 +53,8 @@ from beartype._util.cache.pool.utilcachepoollistfixed import (
 )
 from beartype._util.kind.map.utilmapfrozen import FrozenDict
 
+_AnyHint: Hint = Any
+
 # ....................{ SUBCLASSES                         }....................
 #FIXME: Unit test us up, please.
 class HintsMeta(FixedList):
@@ -679,7 +681,7 @@ class HintsMeta(FixedList):
         # type-checking recursive hints exists. @beartype currently embraces the
         # easiest, fastest, and laziest approach: simply ignore all recursion!
         if id(hint) in self.hint_curr_meta.parent_hint_ids:
-            return Any
+            return _AnyHint
         # Else, this child hint has *NOT* yet been visited by this BFS.
         #
         # If *NO* type variable lookup table was passed, default this table to

--- a/beartype/_util/hint/pep/proposal/pep484585/pep484585container.py
+++ b/beartype/_util/hint/pep/proposal/pep484585/pep484585container.py
@@ -75,7 +75,7 @@ def reduce_hint_pep484585_itemsview(
             #
             # Look. @beartype doesn't make the insane rules. It just enforces
             # them. We pretend this makes the world a better place.
-            Collection[Tuple[hint_key, hint_value]],  # type: ignore[valid-type]
+            Collection[Tuple[hint_key, hint_value]],  # type: ignore[assignment, valid-type]
             # Constrain this collection to be an instance of the expected
             # "collections.abc.ItemsView" abstract base class (ABC).
             IsInstance[ItemsViewABC],


### PR DESCRIPTION
Explanation of changes:

---

1. pep484585container.py:72: error: Incompatible types in assignment (expression has type "<typing special form>", variable has type "TypeForm[Any]")  [assignment]

> 72: hint_reduced = Annotated[Collection[Tuple[hint_key, hint_value]], ...]

mypy is having trouble with `Tuple[hint_key, hint_value]` because (1) it's not a valid type expression (because it has variables `hint_key` and `hint_value`) and (2) it's not a value expression that is of type TypeForm, because typeshed doesn't currently have definitions like:

```
class Tuple:
    def __class_getitem__(*Es: TypeForm) -> TypeForm[Tuple[*Es]]: ...

class Collection:
    def __class_getitem__(E: TypeForm) -> TypeForm[Collection[E]]: ...

class Annotated:
    def __class_getitem__(T: TypeForm, *values) -> TypeForm[Annotated[T, None]]: ...
```

Until typeshed gets those kinds of definitions, we'll need to use a `# type: ignore` for now.

---

2. redpep484585generic.py:90: error: Incompatible return value type (got "<typing special form>", expected "TypeForm[Any] | HintSanifiedData")

> 60: def resolve_hint(hint: str, ...) -> Hint:
> 90:     return hint

Cannot convert `str` directly to a TypeForm because the typechecker can't prove that the `str` spells a valid TypeForm. Fixed by changing `hint: str` to `hint: Hint`, since all callers pass in a Hint (that happens to also be a str).

---

3. redpep484585generic.py:90: error: Incompatible return value type (got "<typing special form>", expected "TypeForm[Any] | HintSanifiedData")  [return-value]

> 28: def reduce_hint_pep484585_generic_subscripted(
> 29:    hint: Hint, exception_prefix: str, **kwargs) -> HintOrHintSanifiedData:
> 90:         return Any

mypy is having trouble because `HintOrHintSanifiedData` is a `Union[Hint, other_stuff]` rather than a direct `Hint`.

Hmm. This is an interesting edge case. PEP 747 says:

> When a static type checker encounters [a type expression], the evaluated type of this expression should be assignable to `TypeForm[T]` if the type it describes is assignable to `T`.

PEP 747 does not say:

> When a static type checker encounters [a type expression], the evaluated type of this expression should be assignable to `TypeForm[T]` or `TypeForm[T] | *anything*` if the type it describes is assignable to `T`.

If PEP 747 did have the latter definition, the `return Any` would have been accepted. Unfortunately the latter definition - although intuitive - is not straightforward to implement safely in mypy... **I'll ask about this issue in the design thread for TypeForm.**

For now can workaround with (1) `return Hint(Any)` or (2) `_AnyHint: Hint = Any` + `return _AnyHint`. I'll use (2) for now since it's more performant.

---

4. redapinumpy.py:244: error: Incompatible return value type (got "<typing special form>", expected "TypeForm[Any]")  [return-value]

> 42: def reduce_hint_numpy_ndarray(...) -> Hint:
> 107: from numpy import ndarray  # pyright: ignore
> 244: return Annotated[ndarray, hint_validator]  # pyright: ignore

It looks like numpy's stubs don't declare `ndarray`, so mypy doesn't know that `ndarray` is a `Type[ndarray]`, and thus mypy doesn't know that `ndarray` can be assigned to a TypeForm. I'll add a `# type: ignore`

---

5. _convcoerce.py:191: error: Incompatible return value type (got "<typing special form>", expected "TypeForm[Any]")  [return-value]

> 67: def coerce_func_hint_root(...) -> Hint:
> 191:         return Union[hint, NotImplementedType]  # pyright: ignore

Same kind of problem as (1). Typeshed currently lacks a definition like:

```
class Union:
    def __class_getitem__(*Ts: TypeForm) -> TypeForm[Union[*Ts]]: ...
```