### PR TITLE
Use 'writer' arg in publish_parts to avoid PendingDeprecationWarning

### DIFF
--- a/beartype_test/a90_func/a80_doc/test_docreadme.py
+++ b/beartype_test/a90_func/a80_doc/test_docreadme.py
@@ -95,7 +95,7 @@ def test_doc_readme(monkeypatch) -> None:
 
     # Attempt to render this "README.rst" file as reST, implicitly invoking this
     # monkey-patch.
-    publish_parts(source=README_CONTENTS, writer_name='html4css1')
+    publish_parts(source=README_CONTENTS, writer='html4css1')
 
     # Assert "docutils" to have emitted *NO* warnings or errors.
     assert not system_messages


### PR DESCRIPTION
Replace the deprecated args in test_docreadme.py test. This prevents a PendingDeprecationWarning from docutils (which pytest was treating as an error) and keeps the test compatible with Docutils current API.

Originally reported https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1120246
