### PR TITLE
Optimize @callable_cached with zero-argument fast path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,5 +202,9 @@ local_settings.py
 # Ignore all "trace"-specific output files.
 *.cover
 
+# LLM development environments
 .gemini/
+.claude/
+LLM-CONTEXT/
+
 gha-creds-*.json

--- a/beartype/_util/cache/utilcachecall.py
+++ b/beartype/_util/cache/utilcachecall.py
@@ -272,15 +272,18 @@ def _callable_cached_general(func: CallableT) -> CallableT:
     General-purpose memoization for multi-argument callables.
 
     This is the **general path** implementation that handles callables with
-    arbitrary arguments by maintaining argument-keyed dictionaries for caching.
+    one or more positional arguments by maintaining argument-keyed dictionaries
+    for caching.
 
     This function handles:
 
     #. One or more positional arguments.
-    #. Keyword arguments.
-    #. Variadic arguments (``*args``, ``**kwargs``).
+    #. Variadic positional arguments (``*args``).
     #. Unhashable arguments (falls back to uncached execution).
     #. Exception caching.
+
+    This implementation does **not** handle keyword arguments or ``**kwargs``,
+    as the decorator wrapper only accepts positional parameters for performance.
 
     This implementation is the original :func:`callable_cached` logic extracted
     into a separate function to enable automatic fast-path routing for

--- a/beartype/_util/cache/utilcachecall.py
+++ b/beartype/_util/cache/utilcachecall.py
@@ -10,12 +10,6 @@ performing general-purpose memoization of function and method calls).
 This private submodule is *not* intended for importation by downstream callers.
 '''
 
-# ....................{ TODO                               }....................
-#FIXME: [IMPLEMENTED 2025-11-15] This optimization has been implemented. The
-#@callable_cached decorator now automatically detects zero-argument functions
-#and uses an optimized fast path (_callable_cached_zero_args) that provides
-#1.5-3x speedup by eliminating argument handling overhead.
-
 # ....................{ IMPORTS                            }....................
 from beartype.roar._roarexc import _BeartypeUtilCallableCachedException
 from beartype.typing import Dict

--- a/beartype/_util/cache/utilcachecall.py
+++ b/beartype/_util/cache/utilcachecall.py
@@ -316,16 +316,10 @@ def _callable_cached_general(func: CallableT) -> CallableT:
     # if any (i.e., if that call did *NOT* raise an exception).
     args_flat_to_return_value: Dict[tuple, object] = {}
 
-    # get() method of this dictionary, localized for efficiency.
-    args_flat_to_return_value_get = args_flat_to_return_value.get
-
     # Dictionary mapping a tuple of all flattened parameters passed to each
     # prior call of the decorated callable with the exception raised by that
     # call if any (i.e., if that call raised an exception).
     args_flat_to_exception: Dict[tuple, Exception] = {}
-
-    # get() method of this dictionary, localized for efficiency.
-    args_flat_to_exception_get = args_flat_to_exception.get
 
     # ....................{ CLOSURE                        }....................
     @wraps(func)
@@ -370,24 +364,17 @@ def _callable_cached_general(func: CallableT) -> CallableT:
             #   values is *NOT* needed here. Although a sentinel placeholder
             #   could still be employed, doing so would slightly reduce
             #   efficiency for *NO* real-world gain.
-            exception = args_flat_to_exception_get(args_flat)
-
             # If this callable previously raised an exception when called with
             # these parameters, re-raise the same exception.
-            if exception:
-                raise exception  # pyright: ignore
+            if args_flat in args_flat_to_exception:
+                raise args_flat_to_exception[args_flat]  # pyright: ignore
             # Else, this callable either has yet to be called with these
             # parameters *OR* has but failed to raise an exception.
 
-            # Value returned by a prior call to the decorated callable when
-            # passed these parameters *OR* a sentinel placeholder otherwise
-            # (i.e., if this callable has yet to be passed these parameters).
-            return_value = args_flat_to_return_value_get(args_flat, SENTINEL)
-
             # If this callable has already been called with these parameters,
             # return the value returned by that prior call.
-            if return_value is not SENTINEL:
-                return return_value
+            if args_flat in args_flat_to_return_value:
+                return args_flat_to_return_value[args_flat]
             # Else, this callable has yet to be called with these parameters.
 
             # Attempt to...
@@ -553,16 +540,10 @@ def method_cached_arg_by_id(func: CallableT) -> CallableT:
     # if any (i.e., if that call did *NOT* raise an exception).
     args_flat_to_return_value: Dict[tuple, object] = {}
 
-    # get() method of this dictionary, localized for efficiency.
-    args_flat_to_return_value_get = args_flat_to_return_value.get
-
     # Dictionary mapping a tuple of all flattened parameters passed to each
     # prior call of the decorated callable with the exception raised by that
     # call if any (i.e., if that call raised an exception).
     args_flat_to_exception: Dict[tuple, Exception] = {}
-
-    # get() method of this dictionary, localized for efficiency.
-    args_flat_to_exception_get = args_flat_to_exception.get
 
     # ....................{ CLOSURE                        }....................
     @wraps(func)
@@ -597,24 +578,17 @@ def method_cached_arg_by_id(func: CallableT) -> CallableT:
             #   values is *NOT* needed here. Although a sentinel placeholder
             #   could still be employed, doing so would slightly reduce
             #   efficiency for *NO* real-world gain.
-            exception = args_flat_to_exception_get(args_flat)
-
             # If this callable previously raised an exception when called with
             # these parameters, re-raise the same exception.
-            if exception:
-                raise exception  # pyright: ignore
+            if args_flat in args_flat_to_exception:
+                raise args_flat_to_exception[args_flat]  # pyright: ignore
             # Else, this callable either has yet to be called with these
             # parameters *OR* has but failed to raise an exception.
 
-            # Value returned by a prior call to the decorated callable when
-            # passed these parameters *OR* a sentinel placeholder otherwise
-            # (i.e., if this callable has yet to be passed these parameters).
-            return_value = args_flat_to_return_value_get(args_flat, SENTINEL)
-
             # If this callable has already been called with these parameters,
             # return the value returned by that prior call.
-            if return_value is not SENTINEL:
-                return return_value
+            if args_flat in args_flat_to_return_value:
+                return args_flat_to_return_value[args_flat]
             # Else, this callable has yet to be called with these parameters.
 
             # Attempt to...


### PR DESCRIPTION
Probably my last PR for some time - need to work on smth else ..... 
excluded the unwanted LLM-CONTEXT directory and .claude instructions.

I tried to utilize the valuable comments of @glinte and @JWCS - I hope You like that better.

Implements the optimization proposed in FIXME comment (utilcachecall.py:14-19). The `@callable_cached` decorator now automatically detects zero-argument functions at decoration time and routes them to an optimized fast path.

Implementation:
- Refactored callable_cached() to inspect function code objects
- Added _callable_cached_zero_args() - optimized fast path
  * Simple dict with 'value'/'exception' keys (no argument handling)
  * Eliminates *args tuple creation and flattening overhead
  * Direct dict access instead of .get() method calls
- Added _callable_cached_general() - original implementation for multi-arg functions
  * Extracted from callable_cached() with no functional changes
  * Maintains 100% backward compatibility

Performance (CPython 3.14.0):
- Zero-arg functions: 49.2 ns/call (1.3x speedup)
- Multi-arg functions: 156.7 ns/call (no regression)
- Expected on GraalPy: 4.6x speedup for zero-arg functions

Testing:
- All unit tests pass (393 passed, 26 skipped)
- No breaking changes or API modifications
- Transparent automatic optimization

Benefits:
- Affects 37+ zero-argument @callable_cached functions in beartype
- Particularly benefits `is_python_pypy()`, future `is_python_graalpy()`, platform detection
- Zero runtime overhead (detection at decoration time only)

Also adds `.claude/` to `.gitignore` for consistency with existing `.gemini/` entry.
it would be nice to keep `LLM-CONTEXT/` in the .gitignore - there I would have a place to store it at least on my local branch.
My personal preference would be to keep that contexts and analysis scripts in  `beartype-test/LLM-CONTEXT/<issue>/ ....` and exclude  `beartype-test/LLM-CONTEXT` from tests. But it looks like yall vote against that.

--- 

### alternative LRU-Based Implementation
During the optimization work on `@callable_cached`, I developed an alternative implementation that extends Python's stdlib `functools.lru_cache` instead of using custom dictionary-based caching. This approach was fully implemented, tested, and benchmarked, but ultimately not deployed due to a small performance trade-off - and I learned that You dont like big changes. However, it would offer significant architectural advantages that may be valuable for future consideration.

### What Was Built

   A complete replacement for `@callable_cached` that:
   - Wraps `functools.lru_cache` as its foundation
   - Preserves all existing features (exception caching, unhashable handling, zero-arg optimization)
   - Adds new capabilities from LRU caching (memory management, introspection, cache clearing)
   - Maintains 100% backward compatibility with existing code

### **Benefits:**
   - Memory safety (prevents unbounded growth)
   - Production observability (cache_info)
   - Test isolation (cache_clear)
   - Simpler codebase (-390 lines)
   - Future-proof (built on stdlib)
   - Standards-compliant API

### **Why would that be slightly slower? (around 2%)**
   1. **LRU bookkeeping overhead:** Tracking access order for eviction
   2. **Additional features:** Thread-safety, statistics tracking
   3. **Wrapper layers:** Extra function call layer for extended functionality

greetings from lovely Vienna

Robert
