### PR TITLE
Make `Any` a subhint of everything

### DIFF
--- a/beartype/door/_cls/doorsuper.py
+++ b/beartype/door/_cls/doorsuper.py
@@ -713,6 +713,9 @@ class TypeHint(Generic[T_Hint], metaclass=_TypeHintMetaclass):
 
         # Return true only if either...
         return (
+            # This hint is the "typing.Any" catch-all (then this hint is
+            # necessarily a subhint of any hint) *OR*...
+            self._hint is Any or
             # That hint is the "typing.Any" catch-all (then this hint is
             # necessarily a subhint of that hint) *OR*...
             other._hint is Any or

--- a/beartype/door/_cls/pep/pep484/doorpep484typevar.py
+++ b/beartype/door/_cls/pep/pep484/doorpep484typevar.py
@@ -18,7 +18,6 @@ from beartype.door._cls.pep.doorpep484604 import UnionTypeHint
 # from beartype.roar import BeartypeDoorPepUnsupportedException
 from beartype.typing import (
     TYPE_CHECKING,
-    Any,
     TypeVar,
 )
 from beartype._util.cache.utilcachecall import property_cached
@@ -104,7 +103,7 @@ class TypeVarTypeHint(UnionTypeHint):
         # Else, this type variable is unconstrained.
 
         #FIXME: Consider globalizing this as a private constant for efficiency.
-        # Return the 1-tuple containing only the "typing.Any" catch-all. Why?
-        # Because an unconstrained and unbounded type variable is semantically
-        # equivalent to a type variable bounded by "typing.Any".
-        return (TypeHint(Any),)  # pyright: ignore
+        # Return the 1-tuple containing only the "object" superclass. Why?
+        # Because PEP 484 states that an unconstrained and unbounded type
+        # variable has an implicit upper bound of "object".
+        return (TypeHint(object),)

--- a/beartype/door/_func/doorfunc.py
+++ b/beartype/door/_func/doorfunc.py
@@ -55,7 +55,6 @@ from beartype._data.typing.datatypingport import (
     TypeIs,
 )
 from beartype._data.typing.datatyping import T
-from beartype.typing import Any
 
 # ....................{ VALIDATORS                         }....................
 def die_if_unbearable(
@@ -310,15 +309,6 @@ def is_subhint(subhint: Hint, superhint: Hint) -> bool:
 
     # Avoid circular import dependencies.
     from beartype.door._cls.doorsuper import TypeHint
-
-    # By design, "typing.Any" is assignable to every type hint at this
-    # public API boundary. Note that this check intentionally lives here
-    # rather than internally in TypeHint.is_subhint(), because unconstrained
-    # TypeVars are internally represented as TypeHint(Any) branches --
-    # making Any a universal subhint internally would incorrectly cause
-    # unconstrained TypeVars to also be subhints of everything.
-    if subhint is Any:
-        return True
 
     # The one-liner is mightier than the... many-liner.
     return TypeHint(subhint).is_subhint(TypeHint(superhint))

--- a/beartype_test/a00_unit/a30_api/door/_fixture/_doorfix_is_subhint.py
+++ b/beartype_test/a00_unit/a30_api/door/_fixture/_doorfix_is_subhint.py
@@ -158,6 +158,10 @@ def door_cases_is_subhint() -> 'Iterable[Tuple[object, object, bool]]':
         (Any, object, True),
         (Any, str | None, True),
 
+        # "Any" nested inside subscripted hints is assignable to concrete types.
+        (List[Any], List[int], True),
+        (List[Any], List[str], True),
+
         # ..................{ PEP 484 ~ argless : bare       }..................
         # PEP 484-compliant unsubscripted type hints, which are necessarily
         # subhints of themselves.


### PR DESCRIPTION
Fixes #530

First commit is a surface level fix that simply fixes `is_subhint(Any, int)` but not `is_subhint(list[Any], list[int])`, second commit reverts that, goes deeper and supposedly should fix everything but it touches deeper internals so I have lower confidence.