### PR TITLE
Remove `no_type_check_decorator` for 3.15+

### DIFF
--- a/beartype/_data/hint/sign/datahintsigns.py
+++ b/beartype/_data/hint/sign/datahintsigns.py
@@ -274,7 +274,6 @@ HintSignLiteralString = _make_typing_hint_sign('LiteralString')
 HintSignNever         = _make_typing_hint_sign('Never')
 HintSignNewType       = _make_typing_hint_sign('NewType')
 # no_type_check   <-- unusable as a type hint
-# no_type_check_decorator   <-- unusable as a type hint
 HintSignNoDefault     = _make_typing_hint_sign('NoDefault')
 
 # Note that "NoReturn" is contextually valid *ONLY* as a top-level return hint.

--- a/beartype/_util/py/utilpyversion.py
+++ b/beartype/_util/py/utilpyversion.py
@@ -81,15 +81,14 @@ IS_PYTHON_AT_LEAST_3_15 = IS_PYTHON_AT_LEAST_3_16 or version_info >= (3, 15)
 '''
 
 
-#FIXME: Preserved if we ever require this. *shrug*
-# #FIXME: After dropping Python 3.14 support:
-# #* Remove all code conditionally testing this global.
-# #* Remove this global.
-# IS_PYTHON_AT_MOST_3_14 = not IS_PYTHON_AT_LEAST_3_15
-# '''
-# :data:`True` only if the active Python interpreter targets at most Python
-# 3.14.x.
-# '''
+#FIXME: After dropping Python 3.14 support:
+#* Remove all code conditionally testing this global.
+#* Remove this global.
+IS_PYTHON_AT_MOST_3_14 = not IS_PYTHON_AT_LEAST_3_15
+'''
+:data:`True` only if the active Python interpreter targets at most Python
+3.14.x.
+'''
 
 
 #FIXME: After dropping Python 3.13 support:

--- a/beartype/typing/__init__.py
+++ b/beartype/typing/__init__.py
@@ -158,6 +158,7 @@ this submodule rather than from :mod:`typing` directly: e.g.,
 from beartype._util.py.utilpyversion import (
     IS_PYTHON_AT_MOST_3_16  as _IS_PYTHON_AT_MOST_3_16,
     IS_PYTHON_AT_MOST_3_15  as _IS_PYTHON_AT_MOST_3_15,
+    IS_PYTHON_AT_MOST_3_14 as _IS_PYTHON_AT_MOST_3_14,
     IS_PYTHON_AT_MOST_3_13  as _IS_PYTHON_AT_MOST_3_13,
     IS_PYTHON_AT_LEAST_3_14 as _IS_PYTHON_AT_LEAST_3_14,
     IS_PYTHON_AT_LEAST_3_13 as _IS_PYTHON_AT_LEAST_3_13,
@@ -214,7 +215,6 @@ from typing import (
     get_type_hints as get_type_hints,
     is_typeddict as is_typeddict,  # pyright: ignore
     no_type_check as no_type_check,
-    no_type_check_decorator as no_type_check_decorator,
     overload as overload,
 )
 
@@ -312,6 +312,16 @@ if _IS_PYTHON_AT_MOST_3_16:
         # Python 3.16 by the upstream CPython issue:
         #     https://github.com/python/cpython/issues/105578
         from typing import AnyStr as AnyStr
+
+# If the active Python interpreter targets at most Python <= 3.14...
+if _IS_PYTHON_AT_MOST_3_14:
+    # "no_type_check_decorator" has been deprecated as largely unused since
+    # 2023 and was removed entirely from 3.15:
+    #     https://github.com/python/cpython/issues/106309
+    #     https://github.com/python/cpython/pull/133602
+    from typing import (
+        no_type_check_decorator as no_type_check_decorator,
+    )
 
 # ....................{ PEP ~ 544                          }....................
 # If this interpreter is performing static type-checking (e.g., via mypy), defer

--- a/beartype_test/a00_unit/a00_core/test_a90_typing.py
+++ b/beartype_test/a00_unit/a00_core/test_a90_typing.py
@@ -51,6 +51,7 @@ def test_api_typing() -> None:
     from beartype._util.py.utilpyversion import (
         IS_PYTHON_AT_MOST_3_16,
         IS_PYTHON_AT_LEAST_3_13,
+        IS_PYTHON_AT_LEAST_3_15,
     )
 
     # ..................{ MAGIC                              }..................
@@ -168,6 +169,13 @@ def test_api_typing() -> None:
         # been permanently removed under newer Python versions.
         TYPING_ATTR_UNEQUAL_NAMES.add('ByteString')
     # Else, the active Python interpreter targets Python >= 3.17.
+
+    # If the active Python interpreter targets Python >= 3.15...
+    if IS_PYTHON_AT_LEAST_3_15:
+        # Add all hard-deprecated public "typing" attributes that have since
+        # been permanently removed under newer Python versions.
+        TYPING_ATTR_UNEQUAL_NAMES.add('no_type_check_decorator')
+    # Else, the active Python interpreter targets Python <= 3.14.
 
     # If the active Python interpreter targets Python >= 3.13...
     if IS_PYTHON_AT_LEAST_3_13:


### PR DESCRIPTION
`no_type_check_decorator` has been [deprecated as largely unused since 2023](https://github.com/python/cpython/issues/106309) and was [removed entirely from 3.15](https://github.com/python/cpython/pull/133602). Its use appears nowhere within `beartype` except as an import to allow `beartype.typing` as a stand-in for `typing`, which currently causes `import beartype.typing` to fail on 3.15.

Fixes #618.