### PR TITLE
`beartype.vale.Is[func,]`

### DIFF
--- a/beartype/vale/_is/_valeis.py
+++ b/beartype/vale/_is/_valeis.py
@@ -299,6 +299,10 @@ class _IsFactory(_BeartypeValidatorFactoryABC):
         '''
 
         # ..................{ VALIDATE                       }..................
+        # Unwrap a 1-tuple subscription (e.g., "Is[func,]") into its sole item.
+        if isinstance(is_valid, tuple) and len(is_valid) == 1:
+            is_valid = is_valid[0]
+
         # If this class was subscripted by either no arguments *OR* two or more
         # arguments, raise an exception.
         self._die_unless_getitem_args_1(is_valid)

--- a/beartype_test/a00_unit/a30_api/vale/_is/test_valeis.py
+++ b/beartype_test/a00_unit/a30_api/vale/_is/test_valeis.py
@@ -94,6 +94,17 @@ def test_api_vale_is_pass() -> None:
     IsExclamatory = Is[_is_exclamatory]
     IsFalseFake = Is[_is_false_fake]
 
+    # Validator produced by subscripting this factory with a 1-tuple, which is
+    # equivalent to subscripting with the sole item of that tuple directly.
+    IsLengthy1Tuple = Is[
+        lambda text: "dark" in text,
+    ]
+    assert isinstance(IsLengthy1Tuple, BeartypeValidator)
+    assert IsLengthy1Tuple.is_valid(
+        'Whose woods these are I think') is False
+    assert IsLengthy1Tuple.is_valid(
+        'The woods are lovely, dark and deep,') is True
+
     # Validator synthesized from the above validators with the domain-specific
     # language (DSL) supported by those validators.
     IsLengthyOrUnquotedSentence = IsLengthy | (IsSentence & ~IsQuoted)


### PR DESCRIPTION
This commit generalizes the `beartype.vale.Is` validator factory to accept 1-tuple subscriptions of the form `beartype.vale.Is[func,]`, and closes #653. Previously, the trailing comma in `Is[func,]`, also known as Colin the cool comma, was rejected with a misleading "two or more arguments" exception, despite Colin being syntactically indistinguishable from the standard `Is[func]` form from any sane caller's perspective. Colin is, after all, a comma; Colin is *not* an argument; and Colin is, without a doubt, cool. Specifically, this commit:

* Unwraps 1-tuple arguments passed to `_IsFactory.__getitem__` into their sole item *before* delegating to `_die_unless_getitem_args_1`, guaranteeing that `Is[func,]` and `Is[func]` produce equivalent validators.
* Augments the corresponding `test_api_vale_is_pass` unit test with a concise assertion exercising Colin in his natural habitat.