### PR TITLE
Accept ParamSpec generic return subscriptions

### DIFF
--- a/beartype/_check/convert/_reduce/_pep/pep646/redpep484612646typearg.py
+++ b/beartype/_check/convert/_reduce/_pep/pep646/redpep484612646typearg.py
@@ -67,6 +67,7 @@ from beartype._check.pep.pep484.checkpep484typevar import (
 from beartype._data.check.error.dataerrmagic import EXCEPTION_PLACEHOLDER
 from beartype._data.hint.sign.datahintsigncls import HintSign
 from beartype._data.hint.sign.datahintsigns import (
+    HintSignParamSpec,
     HintSignTypeVar,
     HintSignPep646TypeVarTupleUnpacked,
 )
@@ -722,7 +723,8 @@ def _die_unless_hint_pep484_typevar_bound_bearable(
     * The passed type parameter is a :pep:`484`-compliant type variable *and*
       the passed child hint violates this type variable's bounds and/or
       constraints.
-    * The passed type parameter is *not* a :pep:`484`-compliant type variable.
+    * The passed type parameter is neither a :pep:`484`-compliant type variable
+      nor a :pep:`612`-compliant parameter specification.
 
     Parameters
     ----------
@@ -746,7 +748,8 @@ def _die_unless_hint_pep484_typevar_bound_bearable(
     Raises
     ------
     BeartypeDecorHintPep484612646Exception
-        If this type parameter is *not* a :pep:`484`-compliant type variable.
+        If this type parameter is neither a :pep:`484`-compliant type variable
+        nor a :pep:`612`-compliant parameter specification.
     BeartypeDecorHintPep484TypeVarViolation
         If this type parameter is a :pep:`484`-compliant type variable *and*
         this child hint violates this type variable's bounds and/or constraints.
@@ -764,8 +767,15 @@ def _die_unless_hint_pep484_typevar_bound_bearable(
         )
         # Else, this child hint satisfies this type variable's bounds and/or
         # constraints.
-    # Else, this type parameter is *NOT* a PEP 484-compliant type variable.
-    # Ergo, this type parameter is *NOT* an unpacked type parameter! *ROAR*.
+    # Else if this type parameter is a PEP 612-compliant parameter
+    # specification, this type parameter accepts any child hint accepted by the
+    # underlying "typing" machinery and defines no bounds or constraints to
+    # validate here.
+    elif hint_typearg_sign is HintSignParamSpec:
+        pass
+    # Else, this type parameter is *NOT* a PEP 484-compliant type variable or a
+    # PEP 612-compliant parameter specification. Ergo, this type parameter is
+    # *NOT* an unpacked type parameter! *ROAR*.
     #
     # Note that this should *NEVER* occur. Python itself syntactically
     # guarantees *ALL* child hints parametrizing a PEP-compliant subscripted

--- a/beartype_test/a00_unit/a60_decor/a60_pep/test_decorpep612.py
+++ b/beartype_test/a00_unit/a60_decor/a60_pep/test_decorpep612.py
@@ -136,3 +136,42 @@ def test_decor_pep612() -> None:
     with raises(BeartypeDecorHintPep612Exception):
         is_bearable(
             'Sends from its woods of musk-rose, twined with jasmine,', P.kwargs)
+
+
+@skip_if_python_version_less_than('3.12.0')
+def test_decor_pep612_paramspec_subscripted_generic_return() -> None:
+    '''
+    Test :pep:`612` parameter specifications subscripting a generic return hint
+    produced by :pep:`695` generic function syntax.
+    '''
+
+    # PEP 695 syntax is only parseable under Python >= 3.12. Defer parsing this
+    # snippet until after the version-gated skip above.
+    scope = {}
+    exec(
+        '''
+from collections.abc import Callable
+from typing import Generic, ParamSpec, TypeVar
+
+from beartype import beartype
+
+P = ParamSpec('P')
+R = TypeVar('R')
+
+class ThroughTheTransparentShadows(Generic[P, R]):
+    pass
+
+@beartype
+def of_the_youth[**Q, T](
+    and_the_sweet_temper_of_the_heart: Callable[Q, T],
+) -> ThroughTheTransparentShadows[Q, T]:
+    return ThroughTheTransparentShadows()
+''',
+        scope,
+    )
+
+    assert isinstance(
+        scope['of_the_youth'](
+            lambda: 'Greener than emeralds on the enchanted mount'),
+        scope['ThroughTheTransparentShadows'],
+    )


### PR DESCRIPTION
## Summary
- allow ParamSpec type parameters to participate in generic subscription mappings without applying TypeVar bound validation
- keep TypeVar bound checks and TypeVarTuple validation behavior unchanged
- add a Python 3.12+ regression test for a PEP 695 generic function returning Generic[Q, T]

Fixes #659.

## Validation
- python -m pytest beartype_test/a00_unit/a60_decor/a60_pep/test_decorpep612.py -q
- python -m pytest beartype_test/a00_unit/a50_check/a40_convert/a00_reduce/pep/test_redpep484612646.py -q
- python -m ruff check beartype/_check/convert/_reduce/_pep/pep646/redpep484612646typearg.py beartype_test/a00_unit/a60_decor/a60_pep/test_decorpep612.py
- git diff --check