### PR TITLE
Set py-3.15 test targets as experimental for now?

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -149,13 +149,17 @@ jobs:
         #   embedded in a single quoted version specifier. For example,
         #   selecting the Python 3.11 pre-release reduces to:
         #     python-version: "3.11.0-alpha - 3.11.0"
+        # * The key/value pair "experimental: true" is used below as
+        #   part of the "continue-on-error" setting so that a failure
+        #   in a job marked as experimental will not short-circuit
+        #   adjacent matrix jobs.
         include:
           - { python-version: "3.10",  tox-env: "py310-coverage" }
           - { python-version: "3.11",  tox-env: "py311-coverage" }
           - { python-version: "3.12",  tox-env: "py312-coverage" }
           - { python-version: "3.13",  tox-env: "py313-coverage" }
           - { python-version: "3.14",  tox-env: "py314-coverage" }
-          - { python-version: "3.15.0-alpha - 3.15.0", tox-env: "py315-coverage" }
+          - { python-version: "3.15.0-alpha - 3.15.0", tox-env: "py315-coverage", experimental: true }
 
           #FIXME: Actually, let's just avoid free-threading builds for now. It'd
           #be great to test them, but only 20% of all C extensions support them
@@ -203,6 +207,25 @@ jobs:
         #     tox-env: py313-coverage
 
     # ..................{ SETTINGS                           }..................
+    # Allow failures for items marked as experimental. To mark
+    # something as experimental, append the key/value pair
+    # "experimental: true" to the appropriate matrix mapping. E.g.:
+    #
+    #   include:
+    #     # ...
+    #     - { python-version: "3.17.0-alpha", tox-env: "py317-coverage", experimental: true }
+    #                                                                    ^^^^^^^^^^^^^^^^^^
+    # The following continue-on-error setting will record failures for
+    # jobs marked experimental, but not prematurely arrest adjacent
+    # matrix runners. This requires jobs to be explicitly marked as
+    # experimental to inherit this setting. Another approach (not used
+    # here) could include pattern matching. E.g.:
+    #
+    #   continue-on-error: ${{ contains(matrix.python-version, 'alpha') || matrix.experimental || false}}
+    #                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^
+    #                              implicit based on version name                explicit
+    continue-on-error: ${{ matrix.experimental || false }}
+
     # Arbitrary human-readable description.
     name: "[${{ matrix.platform }}] Python ${{ matrix.python-version }} CI"
 


### PR DESCRIPTION
_UPDATE: The root cause/motivation for this change has been mitigated (see 1ece3478e2c6c3ec96c0b1a9b853ead4bbdf0859), so an effort to paper over new things may be misguided at this point. Feel free to abandon with ... erm ... abandon._

Uses an "experimental" key in matrix jobs with the "continue-on-error" setting to identify test jobs that may fail, but which shouldn't short-circuit other jobs.

Motivation: At some point recently (probably as a result of something I did), test jobs started to fail for Python 3.15 specifically (e.g., [this one](https://github.com/beartype/beartype/actions/runs/27491595337)). I haven't dug in, but superficially, this looks like a Sphinx version peg incompatibility somewhere?

The side effect of a Python 3.15 test job failing is that the failure will short-circuit other test jobs, so one can't easily tell whether it's a universal failure, or limited to the alpha version. This PR provides a mechanism to mark specific Python implementations as "experimental" so their failures don't hide test execution for stable versions.

This does _**NOT**_ address the root cause for the [Python 3.15 failures, which persist](https://github.com/beartype/beartype/actions/runs/27507513252). That ~is~ _was_ a [separate effort](https://github.com/beartype/beartype/commit/1ece3478e2c6c3ec96c0b1a9b853ead4bbdf0859).