### PR TITLE
Beardantic whispers: a `beartype.loadbearing` proof-of-concept

### DIFF
--- a/beartype/loadbearing/__init__.py
+++ b/beartype/loadbearing/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2026 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+**Beartype load-bearing API** (i.e., public callables deriving portable
+JSON-centric artifacts -- including JSON Schemas -- from type-hinted
+:pep:`557`-compliant dataclasses via runtime introspection).
+
+This subpackage is currently a proof-of-concept exercising a deliberately
+minimal subset of type hints. See the :func:`.to_json_schema` docstring for the
+exact subset currently supported.
+'''
+
+# ....................{ IMPORTS                            }....................
+from beartype.loadbearing._schema import to_json_schema

--- a/beartype/loadbearing/__init__.py
+++ b/beartype/loadbearing/__init__.py
@@ -14,4 +14,8 @@ exact subset currently supported.
 '''
 
 # ....................{ IMPORTS                            }....................
+from beartype.loadbearing._marshal import (
+    from_json,
+    to_json,
+)
 from beartype.loadbearing._schema import to_json_schema

--- a/beartype/loadbearing/_marshal.py
+++ b/beartype/loadbearing/_marshal.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2026 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+**Beartype JSON marshallers** (i.e., low-level callables serializing instances
+of type-hinted :pep:`557`-compliant dataclasses to JSON-encodable dictionaries
+and deserializing such dictionaries back into validated instances).
+'''
+
+# ....................{ IMPORTS                            }....................
+#FIXME: See the sibling "_schema" submodule for commentary on the
+#"type: ignore" below. *sigh*
+from beartype.door import (  # type: ignore[attr-defined]
+    AnyTypeHint,
+    ClassTypeHint,
+    LiteralTypeHint,
+    SubscriptedTypeHint,
+    TupleFixedTypeHint,
+    TupleVariableTypeHint,
+    TypeHint,
+    UnionTypeHint,
+    die_if_unbearable,
+)
+from dataclasses import (
+    MISSING,
+    fields as dataclass_fields,
+    is_dataclass,
+)
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    get_type_hints,
+)
+
+# If statically type-checking, import the stub-only "DataclassInstance"
+# protocol. See the sibling "_schema" submodule for commentary.
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+
+# ....................{ SERIALIZERS                        }....................
+def to_json(datainst: 'DataclassInstance') -> dict:
+    '''
+    JSON-encodable dictionary serialized from the passed :pep:`557`-compliant
+    dataclass instance.
+
+    This proof-of-concept serializer is **structural** rather than
+    hint-driven: values are serialized according to their actual runtime types
+    rather than the type hints annotating their fields. Notably:
+
+    * :class:`enum.Enum` members serialize as their values (*not* names).
+    * Tuples, sets, and frozen sets serialize as JSON arrays (JSON defines
+      *no* tuple or set types). Set iteration order is unspecified; the
+      resulting array ordering is thus unspecified as well.
+    * Nested dataclasses serialize as nested JSON objects.
+
+    Before serializing, however, *all* fields of the passed instance are
+    validated against the type hints annotating those fields by
+    :func:`beartype.door.die_if_unbearable`. Fields of dataclass instances are
+    *not* reliably validated at assignment time (e.g., attribute mutation
+    after instantiation is unchecked even under :func:`beartype.beartype`), so
+    a hint-violating field is entirely possible here -- and would otherwise
+    silently serialize into JSON violating the corresponding
+    :func:`.to_json_schema` schema, deferring discovery to some arbitrarily
+    distant (and arbitrarily confusing) downstream consumer.
+
+    Parameters
+    ----------
+    datainst : DataclassInstance
+        :pep:`557`-compliant dataclass instance to be serialized.
+
+    Returns
+    -------
+    dict
+        JSON-encodable dictionary serialized from this instance.
+
+    Raises
+    ------
+    TypeError
+        If the passed object is *not* a dataclass instance.
+    beartype.roar.BeartypeDoorHintViolation
+        If any field of this instance violates the type hint annotating that
+        field.
+    NotImplementedError
+        If this instance transitively contains one or more values currently
+        unserializable by this proof-of-concept.
+    '''
+
+    # If the passed object is *NOT* a dataclass instance, raise an exception.
+    if not (is_dataclass(datainst) and not isinstance(datainst, type)):
+        raise TypeError(f'{repr(datainst)} not dataclass instance.')
+    # Else, the passed object is a dataclass instance.
+
+    # Dictionary mapping from each field name of this dataclass to the type
+    # hint annotating that field, resolving stringified annotations.
+    field_name_to_hint = get_type_hints(type(datainst))
+
+    # For each field of this instance, validate the current value of this
+    # field against the type hint annotating this field *BEFORE* serializing.
+    #
+    # This is an intentional (and debatable) policy decision. Serialization
+    # and deserialization are typically far apart -- different processes,
+    # different machines, different weeks. A hint-violating field silently
+    # serialized here would surface as a failure at some distant from_json()
+    # call (or worse, a third-party consumer validating against the schema),
+    # where the actual source of the violation is long gone and sussing it out
+    # is much harder. Failing loudly at *THIS* boundary localizes the error to
+    # the process (and stack trace) that actually contains the bad value.
+    #
+    # The counterargument: serialized JSON may never be deserialized or
+    # validated by anyone, rendering these cycles wasted. Alternatives include
+    # serializing faithfully without validation (the prior behaviour of this
+    # proof-of-concept) and warning-but-emitting (roughly Pydantic's
+    # behaviour). This remains an open policy question. See also the
+    # symmetric validation pass concluding from_json() below.
+    for field in dataclass_fields(datainst):
+        die_if_unbearable(
+            getattr(datainst, field.name), field_name_to_hint[field.name])
+
+    # Return the JSON-encodable dictionary serialized from this instance.
+    return {
+        field.name: _value_to_json(getattr(datainst, field.name))
+        for field in dataclass_fields(datainst)
+    }
+
+# ....................{ DESERIALIZERS                      }....................
+def from_json(
+    datacls: 'type[DataclassInstance]', json_dict: dict) -> (
+    'DataclassInstance'):
+    '''
+    Instance of the passed :pep:`557`-compliant dataclass deserialized from the
+    passed JSON-encodable dictionary, validated against the type hints
+    annotating the fields of this dataclass.
+
+    Deserialization is intentionally **strict** rather than coercive: a JSON
+    string is *never* silently converted into an integer (or vice versa). The
+    sole exception is the standard numeric tower accommodation: JSON draws no
+    distinction between ``3`` and ``3.0``, so fields hinted as :class:`float`
+    additionally accept integers (which are converted to floats).
+
+    Additional policy decisions this proof-of-concept intentionally hard-codes:
+
+    * Unrecognized keys are silently ignored (matching Pydantic's default).
+    * Keys omitted for defaulted fields assume their defaults; keys omitted
+      for defaultless fields raise :exc:`ValueError`.
+    * After construction, *all* fields of the deserialized instance are
+      re-validated by :func:`beartype.door.die_if_unbearable`, guaranteeing
+      that :mod:`beartype` itself (rather than this deserializer) is the final
+      authority on well-typedness.
+
+    Parameters
+    ----------
+    datacls : type[DataclassInstance]
+        :pep:`557`-compliant dataclass to be instantiated.
+    json_dict : dict
+        JSON-encodable dictionary to be deserialized.
+
+    Returns
+    -------
+    DataclassInstance
+        Instance of this dataclass deserialized from this dictionary.
+
+    Raises
+    ------
+    TypeError
+        If the passed ``datacls`` is *not* a dataclass *or* the passed
+        ``json_dict`` is *not* a dictionary.
+    ValueError
+        If this dictionary structurally violates this dataclass (e.g., a
+        missing defaultless field, a mistyped scalar, an unknown enumeration
+        value, a fixed-length tuple of the wrong length).
+    beartype.roar.BeartypeDoorHintViolation
+        If any field of the deserialized instance violates the type hint
+        annotating that field.
+    '''
+
+    # If the passed object is *NOT* a dataclass, raise an exception.
+    if not (isinstance(datacls, type) and is_dataclass(datacls)):
+        raise TypeError(f'{repr(datacls)} not dataclass.')
+    # Else, the passed object is a dataclass.
+
+    # If the passed dictionary is *NOT* a dictionary, raise an exception.
+    if not isinstance(json_dict, dict):
+        raise TypeError(f'{repr(json_dict)} not dictionary.')
+    # Else, the passed dictionary is a dictionary.
+
+    # Dictionary mapping from each field name of this dataclass to the type
+    # hint annotating that field, resolving stringified annotations.
+    field_name_to_hint = get_type_hints(datacls)
+
+    # Keyword arguments with which to instantiate this dataclass.
+    field_name_to_value = {}
+
+    # For each field of this dataclass...
+    for field in dataclass_fields(datacls):
+        # If this dictionary supplies this field, deserialize this value
+        # against the type hint annotating this field.
+        if field.name in json_dict:
+            field_name_to_value[field.name] = _json_to_value(
+                json_dict[field.name],
+                TypeHint(field_name_to_hint[field.name]),
+            )
+        # Else if this field is defaultless, this dictionary is missing a
+        # required field. Raise an exception.
+        elif field.default is MISSING and field.default_factory is MISSING:
+            raise ValueError(
+                f'Dataclass {repr(datacls)} field "{field.name}" required '
+                f'but missing from {repr(json_dict)}.')
+        # Else, this field is defaulted. Defer to that default by omitting
+        # this field from these keyword arguments.
+
+    # Instance of this dataclass deserialized from this dictionary.
+    self = datacls(**field_name_to_value)
+
+    # For each field of this dataclass, re-validate the deserialized value of
+    # this field against the type hint annotating this field, deferring to
+    # beartype itself as the final authority on well-typedness.
+    for field in dataclass_fields(datacls):
+        die_if_unbearable(
+            getattr(self, field.name), field_name_to_hint[field.name])
+
+    # Return this instance.
+    return self
+
+# ....................{ PRIVATE ~ serializers              }....................
+def _value_to_json(value: object) -> object:
+    '''
+    JSON-encodable value serialized from the passed arbitrary value.
+    '''
+
+    # If this value is an enumeration member, serialize the value (*NOT* the
+    # name) of this member.
+    #
+    # Note that this test *MUST* precede the scalar test below. Mixin-style
+    # enumerations (e.g., subclassing both "str" and "Enum") are instances of
+    # scalar types; testing scalars first would serialize such members as
+    # themselves rather than their values.
+    if isinstance(value, Enum):
+        return _value_to_json(value.value)
+    # Else if this value is a scalar, serialize this value as is.
+    elif value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    # Else if this value is a dataclass instance, serialize this value as a
+    # nested JSON object.
+    elif is_dataclass(value) and not isinstance(value, type):
+        return to_json(value)
+    # Else if this value is a sequence or set, serialize this value as a JSON
+    # array. Note that set iteration order is unspecified.
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        return [_value_to_json(value_item) for value_item in value]
+    # Else if this value is a dictionary...
+    elif isinstance(value, dict):
+        # If any key of this dictionary is *NOT* a string, this dictionary is
+        # unserializable. JSON object keys are *ALWAYS* strings.
+        for value_key in value:
+            if not isinstance(value_key, str):
+                raise NotImplementedError(
+                    f'Dictionary key {repr(value_key)} currently unsupported '
+                    f'(JSON object keys are strings).')
+        # Else, all keys of this dictionary are strings.
+
+        # Serialize this dictionary as a JSON object.
+        return {
+            value_key: _value_to_json(value_item)
+            for value_key, value_item in value.items()
+        }
+    # Else, this value is currently unserializable. Rise up!
+
+    raise NotImplementedError(f'Value {repr(value)} currently unsupported.')
+
+# ....................{ PRIVATE ~ deserializers            }....................
+def _json_to_value(json_value: object, hint: TypeHint) -> object:
+    '''
+    Value deserialized from the passed JSON-encodable value against the passed
+    :mod:`beartype.door`-normalized type hint.
+    '''
+
+    # If this hint is "typing.Any", deserialize this value as is.
+    if isinstance(hint, AnyTypeHint):
+        return json_value
+    # Else if this hint is a union, deserialize this value against each child
+    # hint of this union in order, returning the first success.
+    elif isinstance(hint, UnionTypeHint):
+        for hint_child in hint.args:
+            try:
+                return _json_to_value(json_value, TypeHint(hint_child))
+            except (ValueError, TypeError):
+                continue
+
+        # No child hint of this union deserialized this value. Rise up!
+        raise ValueError(
+            f'Value {repr(json_value)} deserializable by no child hint of '
+            f'union {repr(hint.hint)}.')
+    # Else if this hint is a "typing.Literal", require this value to *EXACTLY*
+    # equal one of the literals of this hint -- including by type, avoiding
+    # the standard "True == 1" equality pitfall.
+    elif isinstance(hint, LiteralTypeHint):
+        for literal_arg in hint.args:
+            if (
+                type(json_value) is type(literal_arg) and
+                json_value == literal_arg
+            ):
+                return json_value
+
+        raise ValueError(
+            f'Value {repr(json_value)} not a literal of '
+            f'{repr(hint.hint)}.')
+    # Else if this hint is a fixed-length tuple hint, require this value to be
+    # a JSON array of exactly the expected length and deserialize each item
+    # positionally.
+    elif isinstance(hint, TupleFixedTypeHint):
+        if not isinstance(json_value, list):
+            raise ValueError(f'Value {repr(json_value)} not array.')
+        if len(json_value) != len(hint.args):
+            raise ValueError(
+                f'Array {repr(json_value)} length {len(json_value)} != '
+                f'{len(hint.args)} expected by {repr(hint.hint)}.')
+
+        return tuple(
+            _json_to_value(json_item, TypeHint(hint_child))
+            for json_item, hint_child in zip(json_value, hint.args)
+        )
+    # Else if this hint is a variable-length tuple hint, deserialize this
+    # value as a homogeneous tuple.
+    elif isinstance(hint, TupleVariableTypeHint):
+        if not isinstance(json_value, list):
+            raise ValueError(f'Value {repr(json_value)} not array.')
+
+        return tuple(
+            _json_to_value(json_item, TypeHint(hint.args[0]))
+            for json_item in json_value
+        )
+    # Else if this hint is a subscripted container hint, dispatch on the
+    # origin class of this hint.
+    elif isinstance(hint, SubscriptedTypeHint):
+        return _json_to_container(json_value, hint)
+    # Else if this hint is a simple class, dispatch on that class.
+    elif isinstance(hint, ClassTypeHint):
+        return _json_to_scalar(json_value, hint.hint)
+    # Else, this hint is currently undeserializable. Rise up!
+
+    raise NotImplementedError(
+        f'Type hint {repr(hint.hint)} currently unsupported.')
+
+
+def _json_to_container(json_value: object, hint: SubscriptedTypeHint) -> object:
+    '''
+    Container deserialized from the passed JSON-encodable value against the
+    passed subscripted container type hint.
+    '''
+
+    # Origin class of this hint (e.g., "list" for "list[str]").
+    hint_origin = hint.hint.__origin__
+
+    # If this hint is a subscripted list, set, or frozen set, require this
+    # value to be a JSON array and deserialize each item. Note that
+    # deserializing an array containing duplicates into a set silently
+    # collapses those duplicates.
+    if hint_origin in (list, set, frozenset):
+        if not isinstance(json_value, list):
+            raise ValueError(f'Value {repr(json_value)} not array.')
+
+        return hint_origin(
+            _json_to_value(json_item, TypeHint(hint.args[0]))
+            for json_item in json_value
+        )
+    # Else if this hint is a subscripted dictionary, require this value to be
+    # a JSON object and deserialize each value.
+    elif hint_origin is dict:
+        if not isinstance(json_value, dict):
+            raise ValueError(f'Value {repr(json_value)} not object.')
+
+        return {
+            json_key: _json_to_value(json_item, TypeHint(hint.args[1]))
+            for json_key, json_item in json_value.items()
+        }
+    # Else, this subscripted hint is currently undeserializable. Rise up!
+
+    raise NotImplementedError(
+        f'Subscripted type hint {repr(hint.hint)} currently unsupported.')
+
+
+def _json_to_scalar(json_value: object, cls: type) -> object:
+    '''
+    Value deserialized from the passed JSON-encodable value against the passed
+    simple class.
+    '''
+
+    # If this class is a boolean, integer, or string, require this value to be
+    # *EXACTLY* of this class. Note that:
+    # * The boolean case *MUST* be tested by exact type. Booleans are integers
+    #   ("issubclass(bool, int)"); lenient isinstance()-based tests would
+    #   silently deserialize "true" into an integer field (and vice versa).
+    # * Strictness is intentional. JSON already distinguishes strings from
+    #   numbers; coercing between them papers over malformed input.
+    if cls in (bool, int, str):
+        if type(json_value) is not cls:
+            raise ValueError(
+                f'Value {repr(json_value)} not {repr(cls)}.')
+        return json_value
+    # Else if this class is a float, additionally accept integers. JSON draws
+    # *NO* distinction between "3" and "3.0"; a serializer emitting the former
+    # for a float field is well-formed.
+    elif cls is float:
+        if type(json_value) not in (float, int):
+            raise ValueError(f'Value {repr(json_value)} not number.')
+        return float(json_value)  # type: ignore[arg-type]
+    # Else if this class is "None", require this value to be null.
+    elif cls is type(None):
+        if json_value is not None:
+            raise ValueError(f'Value {repr(json_value)} not null.')
+        return None
+    # Else if this class is an enumeration, deserialize this value as the
+    # enumeration member with this value, implicitly raising a "ValueError"
+    # exception for unrecognized values.
+    elif isinstance(cls, type) and issubclass(cls, Enum):
+        return cls(json_value)
+    # Else if this class is itself a dataclass, deserialize this value as a
+    # nested dataclass instance.
+    elif is_dataclass(cls):
+        if not isinstance(json_value, dict):
+            raise ValueError(f'Value {repr(json_value)} not object.')
+        return from_json(cls, json_value)
+    # Else, this class is currently undeserializable. Rise up!
+
+    raise NotImplementedError(f'Class {repr(cls)} currently unsupported.')

--- a/beartype/loadbearing/_schema.py
+++ b/beartype/loadbearing/_schema.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2026 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+**Beartype JSON Schema translator** (i.e., low-level callables translating
+type-hinted :pep:`557`-compliant dataclasses into JSON Schemas via runtime
+introspection of the :mod:`beartype.door` API).
+'''
+
+# ....................{ IMPORTS                            }....................
+#FIXME: "TupleFixedTypeHint" and "TupleVariableTypeHint" are importable from
+#"beartype.door" at runtime but omitted from that subpackage's explicit
+#exports, requiring the "type: ignore" below. Consider explicitly exporting
+#both from "beartype.door" instead.
+from beartype.door import (  # type: ignore[attr-defined]
+    AnyTypeHint,
+    ClassTypeHint,
+    LiteralTypeHint,
+    SubscriptedTypeHint,
+    TupleFixedTypeHint,
+    TupleVariableTypeHint,
+    TypeHint,
+    UnionTypeHint,
+)
+from dataclasses import (
+    MISSING,
+    fields as dataclass_fields,
+    is_dataclass,
+)
+from enum import Enum
+from typing import get_type_hints
+
+# ....................{ PRIVATE ~ globals                  }....................
+_SCALAR_CLS_TO_SCHEMA_TYPE = {
+    str: 'string',
+    int: 'integer',
+    float: 'number',
+    bool: 'boolean',
+    type(None): 'null',
+}
+'''
+Dictionary mapping from each **scalar class** (i.e., builtin type trivially
+translatable into a JSON Schema primitive) to the name of that primitive.
+
+Note that this dictionary is keyed by exact class rather than tested by
+:func:`issubclass`, intentionally avoiding the standard :class:`bool`-is-a-
+:class:`int` subclassing pitfall.
+'''
+
+
+_LITERAL_ARG_CLSES = (str, int, bool, type(None))
+'''
+Tuple of all classes of :obj:`typing.Literal` arguments trivially translatable
+into JSON Schema ``enum`` values.
+
+Note that :pep:`586` additionally permits :class:`bytes` values and
+:class:`enum.Enum` members as literals, *neither* of which are trivially
+JSON-encodable. Ergo, both are currently unsupported.
+'''
+
+# ....................{ TRANSLATORS                        }....................
+def to_json_schema(datacls: type) -> dict:
+    '''
+    JSON Schema (draft 2020-12) validating JSON objects deserializable into
+    instances of the passed :pep:`557`-compliant dataclass.
+
+    This proof-of-concept translator currently supports *only* dataclasses
+    whose fields are recursively hinted by this subset of type hints:
+
+    * Scalars: :class:`str`, :class:`int`, :class:`float`, :class:`bool`,
+      ``None``.
+    * :obj:`typing.Any`, translated as the vacuously true schema ``{}``.
+    * :obj:`typing.Optional` and :obj:`typing.Union`, translated as ``anyOf``.
+    * :obj:`typing.Literal` subscripted by strings, integers, booleans, and/or
+      ``None``, translated as ``const`` (one argument) or ``enum`` (many).
+    * :class:`enum.Enum` subclasses whose member values are all scalars,
+      translated as ``enum`` over those values.
+    * ``list[T]``, ``set[T]``, and ``frozenset[T]``, translated as ``array``
+      (sets additionally imposing ``uniqueItems``).
+    * ``tuple[T, ...]`` translated as ``array``; ``tuple[T1, ..., TN]``
+      translated as ``prefixItems`` with exact length bounds.
+    * ``dict[str, T]``, translated as ``object`` with ``additionalProperties``.
+    * Nested non-recursive dataclasses, translated as inline ``object``
+      subschemas.
+
+    All other hints raise :exc:`NotImplementedError` -- loudly, by design. The
+    list of hints raising that exception is itself a deliverable of this
+    proof-of-concept.
+
+    Design notes (i.e., policy decisions this proof-of-concept intentionally
+    hard-codes rather than exposing as configuration):
+
+    * Fields with defaults (including default factories) are omitted from the
+      ``required`` list; all other fields are required.
+    * ``additionalProperties`` is left unconstrained on dataclass subschemas,
+      matching Pydantic's default.
+    * Nested dataclasses are inlined rather than shared via ``$defs`` and
+      ``$ref`` (where Pydantic deduplicates). Recursive dataclasses thus raise
+      :exc:`NotImplementedError` rather than infinitely recursing.
+
+    Parameters
+    ----------
+    datacls : type
+        :pep:`557`-compliant dataclass to be translated.
+
+    Returns
+    -------
+    dict
+        JSON Schema validating JSON objects deserializable into instances of
+        this dataclass.
+
+    Raises
+    ------
+    TypeError
+        If the passed object is *not* a dataclass.
+    NotImplementedError
+        If this dataclass is transitively hinted by one or more type hints
+        currently unsupported by this proof-of-concept.
+    '''
+
+    # If the passed object is *NOT* a dataclass, raise an exception.
+    if not (isinstance(datacls, type) and is_dataclass(datacls)):
+        raise TypeError(f'{repr(datacls)} not dataclass.')
+    # Else, the passed object is a dataclass.
+
+    # Translate this dataclass with an initially empty recursion guard.
+    return _dataclass_to_schema(datacls, _dataclses_pending=())
+
+
+# ....................{ PRIVATE ~ translators              }....................
+def _dataclass_to_schema(datacls: type, _dataclses_pending: tuple) -> dict:
+    '''
+    JSON Schema ``object`` subschema validating JSON objects deserializable
+    into instances of the passed dataclass.
+
+    Parameters
+    ----------
+    datacls : type
+        :pep:`557`-compliant dataclass to be translated.
+    _dataclses_pending : tuple
+        Tuple of all dataclasses transitively containing this dataclass whose
+        translations are still in progress, guarding against infinite recursion
+        over recursive dataclasses.
+    '''
+
+    # If this dataclass is already being translated, this dataclass is
+    # recursive. Since this proof-of-concept inlines (rather than referencing)
+    # nested subschemas, recursion is currently untranslatable.
+    if datacls in _dataclses_pending:
+        raise NotImplementedError(
+            f'Recursive dataclass {repr(datacls)} currently unsupported '
+            f'(requires "$defs"- and "$ref"-based subschema references).')
+    # Else, this dataclass is *NOT* already being translated.
+
+    # Extend the recursion guard by this dataclass.
+    _dataclses_pending += (datacls,)
+
+    # Dictionary mapping from each field name of this dataclass to the type
+    # hint annotating that field, resolving stringified (e.g., PEP 563-style
+    # postponed) annotations into their referents.
+    field_name_to_hint = get_type_hints(datacls)
+
+    # "properties" and "required" components of the schema to be returned.
+    properties = {}
+    required = []
+
+    # For each field of this dataclass...
+    for field in dataclass_fields(datacls):
+        # Translate the type hint annotating this field into a subschema.
+        properties[field.name] = _hint_to_schema(
+            TypeHint(field_name_to_hint[field.name]), _dataclses_pending)
+
+        # If this field is defaultless, deserializing an instance of this
+        # dataclass requires this field.
+        if field.default is MISSING and field.default_factory is MISSING:
+            required.append(field.name)
+        # Else, this field is defaulted and thus optional.
+
+    # Schema validating JSON objects deserializable into this dataclass.
+    schema: dict = {
+        'title': datacls.__name__,
+        'type': 'object',
+        'properties': properties,
+    }
+
+    # Require all defaultless fields, if any.
+    if required:
+        schema['required'] = required
+
+    # Return this schema.
+    return schema
+
+
+def _hint_to_schema(hint: TypeHint, _dataclses_pending: tuple) -> dict:
+    '''
+    JSON Schema subschema validating JSON values deserializable into objects
+    satisfying the passed type hint.
+
+    Parameters
+    ----------
+    hint : TypeHint
+        :mod:`beartype.door`-normalized type hint to be translated.
+    _dataclses_pending : tuple
+        Tuple of all dataclasses whose translations are still in progress. See
+        :func:`._dataclass_to_schema`.
+    '''
+
+    # If this hint is "typing.Any", *ANY* JSON value is valid. Return the
+    # vacuously true schema.
+    if isinstance(hint, AnyTypeHint):
+        return {}
+    # Else if this hint is a union (e.g., "typing.Optional", "typing.Union",
+    # PEP 604-compliant "|"-delimited unions), return the "anyOf" of the
+    # translations of all child hints of this union.
+    elif isinstance(hint, UnionTypeHint):
+        return {'anyOf': [
+            _hint_to_schema(TypeHint(hint_child), _dataclses_pending)
+            for hint_child in hint.args
+        ]}
+    # Else if this hint is a "typing.Literal", return either a "const" schema
+    # (for exactly one literal) or an "enum" schema (for two or more).
+    elif isinstance(hint, LiteralTypeHint):
+        # If any literal is *NOT* trivially JSON-encodable (e.g., a "bytes"
+        # value or "enum.Enum" member), raise an exception.
+        for literal_arg in hint.args:
+            if not isinstance(literal_arg, _LITERAL_ARG_CLSES):
+                raise NotImplementedError(
+                    f'Literal {repr(literal_arg)} currently unsupported '
+                    f'(not a string, integer, boolean, or "None").')
+        # Else, all literals are trivially JSON-encodable.
+
+        # Return the appropriate schema for this arity.
+        return (
+            {'const': hint.args[0]}
+            if len(hint.args) == 1 else
+            {'enum': list(hint.args)}
+        )
+    # Else if this hint is a fixed-length tuple hint (e.g., "tuple[int, str]"),
+    # return a positional "prefixItems" schema with exact length bounds.
+    elif isinstance(hint, TupleFixedTypeHint):
+        return {
+            'type': 'array',
+            'prefixItems': [
+                _hint_to_schema(TypeHint(hint_child), _dataclses_pending)
+                for hint_child in hint.args
+            ],
+            'minItems': len(hint.args),
+            'maxItems': len(hint.args),
+        }
+    # Else if this hint is a variable-length tuple hint (e.g.,
+    # "tuple[int, ...]"), return a homogeneous "array" schema.
+    elif isinstance(hint, TupleVariableTypeHint):
+        return {
+            'type': 'array',
+            'items': _hint_to_schema(
+                TypeHint(hint.args[0]), _dataclses_pending),
+        }
+    # Else if this hint is a subscripted container hint (e.g., "list[str]",
+    # "dict[str, int]"), dispatch on the origin class of this hint.
+    elif isinstance(hint, SubscriptedTypeHint):
+        return _hint_subscripted_to_schema(hint, _dataclses_pending)
+    # Else if this hint is a simple class...
+    elif isinstance(hint, ClassTypeHint):
+        return _cls_to_schema(hint.hint, _dataclses_pending)
+    # Else, this hint is currently untranslatable. Rise up!
+
+    raise NotImplementedError(
+        f'Type hint {repr(hint.hint)} currently unsupported.')
+
+
+def _hint_subscripted_to_schema(
+    hint: SubscriptedTypeHint, _dataclses_pending: tuple) -> dict:
+    '''
+    JSON Schema subschema validating JSON values deserializable into objects
+    satisfying the passed subscripted container type hint (e.g., ``list[str]``,
+    ``dict[str, int]``).
+    '''
+
+    # Origin class of this hint (e.g., "list" for "list[str]").
+    hint_origin = hint.hint.__origin__
+
+    # If this hint is a subscripted list, return an "array" schema.
+    if hint_origin is list:
+        return {
+            'type': 'array',
+            'items': _hint_to_schema(
+                TypeHint(hint.args[0]), _dataclses_pending),
+        }
+    # Else if this hint is a subscripted set or frozen set, return an "array"
+    # schema additionally imposing item uniqueness. Note that JSON itself
+    # defines *NO* set type; arrays of unique items are the conventional
+    # JSON Schema approximation.
+    elif hint_origin in (set, frozenset):
+        return {
+            'type': 'array',
+            'items': _hint_to_schema(
+                TypeHint(hint.args[0]), _dataclses_pending),
+            'uniqueItems': True,
+        }
+    # Else if this hint is a subscripted dictionary...
+    elif hint_origin is dict:
+        # If the keys of this dictionary are *NOT* hinted as strings, this
+        # dictionary is untranslatable. JSON object keys are *ALWAYS* strings.
+        if hint.args[0] is not str:
+            raise NotImplementedError(
+                f'Dictionary key hint {repr(hint.args[0])} currently '
+                f'unsupported (JSON object keys are strings).')
+        # Else, the keys of this dictionary are hinted as strings.
+
+        # Return an "object" schema constraining all values.
+        return {
+            'type': 'object',
+            'additionalProperties': _hint_to_schema(
+                TypeHint(hint.args[1]), _dataclses_pending),
+        }
+    # Else, this subscripted hint is currently untranslatable. Rise up!
+
+    raise NotImplementedError(
+        f'Subscripted type hint {repr(hint.hint)} currently unsupported.')
+
+
+def _cls_to_schema(cls: type, _dataclses_pending: tuple) -> dict:
+    '''
+    JSON Schema subschema validating JSON values deserializable into instances
+    of the passed simple class.
+    '''
+
+    # Name of the JSON Schema primitive validating this class if this class is
+    # a scalar *OR* "None" otherwise.
+    schema_type = _SCALAR_CLS_TO_SCHEMA_TYPE.get(cls)
+
+    # If this class is a scalar, return the corresponding primitive schema.
+    if schema_type is not None:
+        return {'type': schema_type}
+    # Else if this class is an enumeration, return an "enum" schema over the
+    # values (*NOT* the names) of all members of this enumeration.
+    elif isinstance(cls, type) and issubclass(cls, Enum):
+        # If any member value is *NOT* trivially JSON-encodable, this
+        # enumeration is untranslatable.
+        for enum_member in cls:
+            if not isinstance(enum_member.value, _LITERAL_ARG_CLSES + (float,)):
+                raise NotImplementedError(
+                    f'Enumeration member value '
+                    f'{repr(enum_member.value)} currently unsupported '
+                    f'(not JSON-encodable).')
+        # Else, all member values are trivially JSON-encodable.
+
+        # Return this "enum" schema.
+        return {
+            'title': cls.__name__,
+            'enum': [enum_member.value for enum_member in cls],
+        }
+    # Else if this class is itself a dataclass, return the inline "object"
+    # subschema translating this nested dataclass.
+    elif is_dataclass(cls):
+        return _dataclass_to_schema(cls, _dataclses_pending)
+    # Else, this class is currently untranslatable. Rise up!
+
+    raise NotImplementedError(f'Class {repr(cls)} currently unsupported.')

--- a/beartype/loadbearing/_schema.py
+++ b/beartype/loadbearing/_schema.py
@@ -30,7 +30,20 @@ from dataclasses import (
     is_dataclass,
 )
 from enum import Enum
-from typing import get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    get_type_hints,
+)
+
+# If statically type-checking, import the stub-only "DataclassInstance"
+# protocol. "Dataclass instance" is *NOT* a nominally expressible type:
+# the @dataclass decorator adds *NO* superclass, rendering dataclass-ness
+# purely structural. Typeshed defines this protocol (matching any class
+# defining "__dataclass_fields__") for precisely this reason. Since the
+# "_typeshed" module exists *ONLY* at static type-checking time, this import
+# *CANNOT* be performed at runtime.
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
 
 # ....................{ PRIVATE ~ globals                  }....................
 _SCALAR_CLS_TO_SCHEMA_TYPE = {
@@ -61,7 +74,7 @@ JSON-encodable. Ergo, both are currently unsupported.
 '''
 
 # ....................{ TRANSLATORS                        }....................
-def to_json_schema(datacls: type) -> dict:
+def to_json_schema(datacls: 'type[DataclassInstance]') -> dict:
     '''
     JSON Schema (draft 2020-12) validating JSON objects deserializable into
     instances of the passed :pep:`557`-compliant dataclass.
@@ -102,7 +115,7 @@ def to_json_schema(datacls: type) -> dict:
 
     Parameters
     ----------
-    datacls : type
+    datacls : type[DataclassInstance]
         :pep:`557`-compliant dataclass to be translated.
 
     Returns

--- a/beartype_test/a00_unit/a40_api/loadbearing/test_api_loadbearing.py
+++ b/beartype_test/a00_unit/a40_api/loadbearing/test_api_loadbearing.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2026 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+**Beartype load-bearing API unit tests.**
+
+This submodule unit tests the public :mod:`beartype.loadbearing` subpackage.
+'''
+
+# ....................{ IMPORTS                            }....................
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# WARNING: To raise human-readable test errors, avoid importing from
+# package-specific submodules at module scope.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+# ....................{ TESTS ~ scalar                     }....................
+def test_to_json_schema_scalars() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json_schema` translator against a
+    dataclass hinted by scalar types, additionally validating that defaulted
+    fields are omitted from the ``"required"`` list.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class DeepInTheShadySadnessOfAVale:
+        far_sunken: str
+        from_the_healthy_breath_of_morn: int
+        grey_haired_saturn: float
+        quiet_as_a_stone: bool = True
+        still_as_the_silence: list[str] = field(default_factory=list)
+
+    # Assert this dataclass translates to the expected schema.
+    assert to_json_schema(DeepInTheShadySadnessOfAVale) == {
+        'title': 'DeepInTheShadySadnessOfAVale',
+        'type': 'object',
+        'properties': {
+            'far_sunken': {'type': 'string'},
+            'from_the_healthy_breath_of_morn': {'type': 'integer'},
+            'grey_haired_saturn': {'type': 'number'},
+            'quiet_as_a_stone': {'type': 'boolean'},
+            'still_as_the_silence': {
+                'type': 'array', 'items': {'type': 'string'}},
+        },
+        'required': [
+            'far_sunken',
+            'from_the_healthy_breath_of_morn',
+            'grey_haired_saturn',
+        ],
+    }
+
+# ....................{ TESTS ~ union                      }....................
+def test_to_json_schema_union() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json_schema` translator against
+    dataclasses hinted by optionals and unions.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass
+    from typing import (
+        Optional,
+        Union,
+    )
+
+    @dataclass
+    class UponTheSoddenGround:
+        his_old_right_hand: Optional[str]
+        nerveless_listless_dead: Union[int, float]
+
+    # Schema translated from this dataclass.
+    schema = to_json_schema(UponTheSoddenGround)
+
+    # Assert both unions translated to "anyOf" schemas. Note that the ordering
+    # of "anyOf" members is *NOT* asserted, as "beartype.door" reserves the
+    # right to normalize the ordering of union child hints.
+    his_old_right_hand = schema['properties']['his_old_right_hand']
+    assert sorted(
+        any_of['type'] for any_of in his_old_right_hand['anyOf']) == [
+        'null', 'string']
+
+    nerveless = schema['properties']['nerveless_listless_dead']
+    assert sorted(any_of['type'] for any_of in nerveless['anyOf']) == [
+        'integer', 'number']
+
+    # Assert both defaultless fields are required.
+    assert schema['required'] == [
+        'his_old_right_hand', 'nerveless_listless_dead']
+
+# ....................{ TESTS ~ literal : enum             }....................
+def test_to_json_schema_literal() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json_schema` translator against a
+    dataclass hinted by :obj:`typing.Literal` hints.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass
+    from typing import Literal
+
+    @dataclass
+    class NoStirOfAir:
+        was_there: Literal['Not so much life as on a summer\'s day']
+        robs_not: Literal['one light seed', 'from the feather\'d grass', 42]
+
+    # Schema translated from this dataclass.
+    schema = to_json_schema(NoStirOfAir)
+
+    # Assert the single-literal hint translated to a "const" schema.
+    assert schema['properties']['was_there'] == {
+        'const': "Not so much life as on a summer's day"}
+
+    # Assert the multi-literal hint translated to an "enum" schema.
+    assert schema['properties']['robs_not'] == {
+        'enum': ['one light seed', "from the feather'd grass", 42]}
+
+
+def test_to_json_schema_enum() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json_schema` translator against a
+    dataclass hinted by an :class:`enum.Enum` subclass.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass
+    from enum import Enum
+
+    class ForestOnForest(Enum):
+        HUNG_ABOUT_HIS_HEAD = 'hung about his head'
+        LIKE_CLOUD_ON_CLOUD = 'like cloud on cloud'
+
+    @dataclass
+    class ShadyVale:
+        canopy: ForestOnForest
+
+    # Assert this enumeration translated to an "enum" schema over the *VALUES*
+    # (rather than names) of all enumeration members.
+    assert to_json_schema(ShadyVale)['properties']['canopy'] == {
+        'title': 'ForestOnForest',
+        'enum': ['hung about his head', 'like cloud on cloud'],
+    }
+
+# ....................{ TESTS ~ container                  }....................
+def test_to_json_schema_containers() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json_schema` translator against a
+    dataclass hinted by subscripted container hints.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass
+    from typing import Any
+
+    @dataclass
+    class AlongTheMarginSand:
+        large_footmarks: dict[str, int]
+        went_no_further: set[str]
+        than_where_his_feet: tuple[str, int]
+        had_stray_d: tuple[float, ...]
+        and_slept: Any
+
+    # Schema translated from this dataclass.
+    schema = to_json_schema(AlongTheMarginSand)
+    properties = schema['properties']
+
+    # Assert each container hint translated as expected.
+    assert properties['large_footmarks'] == {
+        'type': 'object', 'additionalProperties': {'type': 'integer'}}
+    assert properties['went_no_further'] == {
+        'type': 'array', 'items': {'type': 'string'}, 'uniqueItems': True}
+    assert properties['than_where_his_feet'] == {
+        'type': 'array',
+        'prefixItems': [{'type': 'string'}, {'type': 'integer'}],
+        'minItems': 2,
+        'maxItems': 2,
+    }
+    assert properties['had_stray_d'] == {
+        'type': 'array', 'items': {'type': 'number'}}
+
+    # Assert "typing.Any" translated to the vacuously true schema.
+    assert properties['and_slept'] == {}
+
+# ....................{ TESTS ~ nest                       }....................
+def test_to_json_schema_nested() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json_schema` translator against a
+    dataclass nesting another dataclass.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass
+
+    @dataclass
+    class VoicelessStream:
+        still_deadened_more: str
+
+    @dataclass
+    class ByReasonOfHisFallenDivinity:
+        a_stream_went: VoicelessStream
+
+    # Assert the nested dataclass translated to an inline "object" subschema.
+    assert to_json_schema(ByReasonOfHisFallenDivinity) == {
+        'title': 'ByReasonOfHisFallenDivinity',
+        'type': 'object',
+        'properties': {
+            'a_stream_went': {
+                'title': 'VoicelessStream',
+                'type': 'object',
+                'properties': {
+                    'still_deadened_more': {'type': 'string'},
+                },
+                'required': ['still_deadened_more'],
+            },
+        },
+        'required': ['a_stream_went'],
+    }
+
+# ....................{ TESTS ~ fail                       }....................
+def test_to_json_schema_unsupported() -> None:
+    '''
+    Test that the :func:`beartype.loadbearing.to_json_schema` translator raises
+    the expected exceptions when passed unsupported objects, validating that
+    unsupported hints fail loudly rather than degrading silently.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from collections.abc import Callable
+    from dataclasses import dataclass
+    from pytest import raises
+
+    # Assert that non-dataclasses are rejected.
+    with raises(TypeError):
+        to_json_schema('But where the dead leaf fell, there did it rest.')
+
+    # Assert that a currently untranslatable hint (e.g., a callable) is
+    # rejected loudly.
+    @dataclass
+    class APlaceBeyondOurMemory:
+        listener: Callable[[], None]
+
+    with raises(NotImplementedError):
+        to_json_schema(APlaceBeyondOurMemory)
+
+    # Assert that dictionaries keyed by non-strings are rejected loudly, as
+    # JSON object keys are *ALWAYS* strings.
+    @dataclass
+    class SpiritedSighs:
+        keyed_wrongly: dict[int, str]
+
+    with raises(NotImplementedError):
+        to_json_schema(SpiritedSighs)
+
+
+def test_to_json_schema_recursive() -> None:
+    '''
+    Test that the :func:`beartype.loadbearing.to_json_schema` translator raises
+    the expected exception when passed a recursive dataclass, which this
+    proof-of-concept intentionally does *not* yet support.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import dataclass
+    from pytest import raises
+
+    @dataclass
+    class OnJuttingBoughs:
+        the_frost: 'OnJuttingBoughs'
+
+    # Monkey-patch this locally defined dataclass into module scope, enabling
+    # the stringified self-referential hint above to be resolved by
+    # typing.get_type_hints() against this module's namespace.
+    globals()['OnJuttingBoughs'] = OnJuttingBoughs
+
+    # Assert that this recursive dataclass is rejected loudly.
+    with raises(NotImplementedError):
+        to_json_schema(OnJuttingBoughs)

--- a/beartype_test/a00_unit/a40_api/loadbearing/test_api_loadbearing_json.py
+++ b/beartype_test/a00_unit/a40_api/loadbearing/test_api_loadbearing_json.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2026 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+**Beartype load-bearing JSON marshaller unit tests.**
+
+This submodule unit tests the public :func:`beartype.loadbearing.to_json` and
+:func:`beartype.loadbearing.from_json` marshallers.
+'''
+
+# ....................{ IMPORTS                            }....................
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# WARNING: To raise human-readable test errors, avoid importing from
+# package-specific submodules at module scope.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+from dataclasses import (
+    dataclass,
+    field,
+)
+from enum import Enum
+from typing import Optional
+
+# ....................{ DATA                               }....................
+# Module-scoped test dataclasses. Unlike the sibling schema-centric test
+# submodule (which locally scopes throwaway dataclasses), marshalling tests
+# reuse this shared fixture data across serialization, deserialization, and
+# round-trip tests.
+
+class ThroughAllHisBulk(Enum):
+    '''
+    Arbitrary enumeration whose member values are all JSON-encodable.
+    '''
+
+    AN_AGONY = 'an agony'
+    CREPT_GRADUAL = 'crept gradual'
+
+
+@dataclass
+class MortalImmortal:
+    '''
+    Arbitrary nested dataclass.
+    '''
+
+    from_the_feet: str
+    unto_the_crown: int
+
+
+@dataclass
+class SlowPace(object):
+    '''
+    Arbitrary dataclass exercising the full currently supported hint subset.
+    '''
+
+    palsied_tongue: str
+    made_his_hand: MortalImmortal
+    a_vast_shade: ThroughAllHisBulk
+    in_midst_of_his_own_brightness: Optional[float]
+    like_the_bulk: list[int]
+    of_memnons_image: tuple[str, int]
+    at_the_set: tuple[float, ...] = ()
+    of_sun: dict[str, bool] = field(default_factory=dict)
+
+
+def _make_slow_pace() -> SlowPace:
+    '''
+    Arbitrary fully populated instance of the :class:`SlowPace` dataclass.
+    '''
+
+    return SlowPace(
+        palsied_tongue='And all its ancient sway',
+        made_his_hand=MortalImmortal(
+            from_the_feet='to shine upon the sun', unto_the_crown=7),
+        a_vast_shade=ThroughAllHisBulk.AN_AGONY,
+        in_midst_of_his_own_brightness=0.5,
+        like_the_bulk=[1, 2, 3],
+        of_memnons_image=('dusk', 2),
+        at_the_set=(1.0, 2.5),
+        of_sun={'harp': True, 'strings': False},
+    )
+
+# ....................{ TESTS ~ serialize                  }....................
+def test_to_json() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.to_json` serializer.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json
+    from pytest import raises
+
+    # Assert a fully populated instance serializes to the expected dictionary,
+    # notably serializing enumeration members as their values, nested
+    # dataclasses as nested objects, and tuples as arrays.
+    assert to_json(_make_slow_pace()) == {
+        'palsied_tongue': 'And all its ancient sway',
+        'made_his_hand': {
+            'from_the_feet': 'to shine upon the sun', 'unto_the_crown': 7},
+        'a_vast_shade': 'an agony',
+        'in_midst_of_his_own_brightness': 0.5,
+        'like_the_bulk': [1, 2, 3],
+        'of_memnons_image': ['dusk', 2],
+        'at_the_set': [1.0, 2.5],
+        'of_sun': {'harp': True, 'strings': False},
+    }
+
+    # Assert that non-instances are rejected.
+    with raises(TypeError):
+        to_json(SlowPace)
+    with raises(TypeError):
+        to_json('Sat gray-hair\'d Saturn, quiet as a stone,')
+
+
+def test_to_json_violation() -> None:
+    '''
+    Test that the :func:`beartype.loadbearing.to_json` serializer validates
+    fields against their type hints *before* serializing, failing loudly on a
+    hint-violating instance rather than silently serializing JSON violating
+    the corresponding :func:`beartype.loadbearing.to_json_schema` schema.
+
+    Field assignment on dataclass instances is unchecked; a latent violation
+    introduced by post-instantiation mutation would otherwise surface only at
+    some arbitrarily distant deserialization (or schema validation) far from
+    the code that actually introduced it.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json
+    from beartype.roar import BeartypeDoorHintViolation
+    from pytest import raises
+
+    # Well-formed instance of this dataclass.
+    mortal_immortal = MortalImmortal(
+        from_the_feet='to shine upon the sun', unto_the_crown=7)
+
+    # Mutate a field of this instance into violating its type hint. Dataclass
+    # attribute assignment is unchecked; this mutation succeeds silently.
+    mortal_immortal.unto_the_crown = (  # type: ignore[assignment]
+        'no longer an integer')
+
+    # Assert that serializing this now-violating instance fails loudly.
+    with raises(BeartypeDoorHintViolation):
+        to_json(mortal_immortal)
+
+# ....................{ TESTS ~ deserialize                }....................
+def test_from_json() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.from_json` deserializer against
+    well-formed input.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import from_json
+
+    # Assert a well-formed dictionary deserializes to the expected instance.
+    assert from_json(SlowPace, {
+        'palsied_tongue': 'And all its ancient sway',
+        'made_his_hand': {
+            'from_the_feet': 'to shine upon the sun', 'unto_the_crown': 7},
+        'a_vast_shade': 'an agony',
+        'in_midst_of_his_own_brightness': None,
+        'like_the_bulk': [],
+        'of_memnons_image': ['dusk', 2],
+    }) == SlowPace(
+        palsied_tongue='And all its ancient sway',
+        made_his_hand=MortalImmortal(
+            from_the_feet='to shine upon the sun', unto_the_crown=7),
+        a_vast_shade=ThroughAllHisBulk.AN_AGONY,
+        in_midst_of_his_own_brightness=None,
+        like_the_bulk=[],
+        of_memnons_image=('dusk', 2),
+
+        # Defaulted fields intentionally omitted from the dictionary above,
+        # asserting that defaults apply.
+        at_the_set=(),
+        of_sun={},
+    )
+
+    # Assert that fields hinted as floats additionally accept integers (JSON
+    # draws *NO* distinction between "3" and "3.0"), converted to floats.
+    numbered = from_json(SlowPace, {
+        'palsied_tongue': 'His ancient mother',
+        'made_his_hand': {'from_the_feet': 'for some comfort', 'unto_the_crown': 1},
+        'a_vast_shade': 'crept gradual',
+        'in_midst_of_his_own_brightness': 3,
+        'like_the_bulk': [],
+        'of_memnons_image': ['yet', 0],
+    })
+    assert numbered.in_midst_of_his_own_brightness == 3.0
+    assert type(numbered.in_midst_of_his_own_brightness) is float
+
+    # Assert that unrecognized keys are silently ignored.
+    assert from_json(MortalImmortal, {
+        'from_the_feet': 'to shine upon the sun',
+        'unto_the_crown': 7,
+        'unrecognized_key': 'is silently ignored',
+    }) == MortalImmortal(
+        from_the_feet='to shine upon the sun', unto_the_crown=7)
+
+
+def test_from_json_invalid() -> None:
+    '''
+    Test the :func:`beartype.loadbearing.from_json` deserializer against
+    malformed input, validating strict (non-coercive) deserialization.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import from_json
+    from pytest import raises
+
+    # Assert that non-dataclasses and non-dictionaries are rejected.
+    with raises(TypeError):
+        from_json('no dataclass here', {})
+    with raises(TypeError):
+        from_json(MortalImmortal, 'no dictionary here')
+
+    # Assert that missing defaultless fields are rejected.
+    with raises(ValueError):
+        from_json(MortalImmortal, {'from_the_feet': 'alone'})
+
+    # Assert that mistyped scalars are rejected rather than coerced.
+    with raises(ValueError):
+        from_json(MortalImmortal, {
+            'from_the_feet': 'to shine upon the sun',
+            'unto_the_crown': '7',
+        })
+
+    # Assert that booleans are *NOT* accepted as integers, avoiding the
+    # standard "issubclass(bool, int)" pitfall.
+    with raises(ValueError):
+        from_json(MortalImmortal, {
+            'from_the_feet': 'to shine upon the sun',
+            'unto_the_crown': True,
+        })
+
+    # Assert that unrecognized enumeration values are rejected.
+    with raises(ValueError):
+        from_json(SlowPace, {
+            'palsied_tongue': 'His ancient mother',
+            'made_his_hand': {'from_the_feet': 'x', 'unto_the_crown': 1},
+            'a_vast_shade': 'no such member value',
+            'in_midst_of_his_own_brightness': None,
+            'like_the_bulk': [],
+            'of_memnons_image': ['yet', 0],
+        })
+
+    # Assert that fixed-length tuples of the wrong length are rejected.
+    with raises(ValueError):
+        from_json(SlowPace, {
+            'palsied_tongue': 'His ancient mother',
+            'made_his_hand': {'from_the_feet': 'x', 'unto_the_crown': 1},
+            'a_vast_shade': 'an agony',
+            'in_midst_of_his_own_brightness': None,
+            'like_the_bulk': [],
+            'of_memnons_image': ['too', 2, 'many'],
+        })
+
+# ....................{ TESTS ~ round-trip                 }....................
+def test_json_round_trip() -> None:
+    '''
+    Test that the :func:`beartype.loadbearing.to_json` and
+    :func:`beartype.loadbearing.from_json` marshallers round-trip: serializing
+    an instance and deserializing the result yields an equal instance, and
+    deserializing a canonical dictionary and re-serializing yields an equal
+    dictionary.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import (
+        from_json,
+        to_json,
+    )
+
+    # Assert the instance-first round-trip preserves equality.
+    slow_pace = _make_slow_pace()
+    assert from_json(SlowPace, to_json(slow_pace)) == slow_pace
+
+    # Assert the dictionary-first round-trip preserves equality. Note that
+    # this dictionary intentionally supplies *ALL* fields (including
+    # defaulted fields), as to_json() unconditionally serializes all fields.
+    json_dict = {
+        'palsied_tongue': 'And all its ancient sway',
+        'made_his_hand': {
+            'from_the_feet': 'to shine upon the sun', 'unto_the_crown': 7},
+        'a_vast_shade': 'crept gradual',
+        'in_midst_of_his_own_brightness': None,
+        'like_the_bulk': [3, 2, 1],
+        'of_memnons_image': ['dusk', 2],
+        'at_the_set': [2.5],
+        'of_sun': {'harp': False},
+    }
+    assert to_json(from_json(SlowPace, json_dict)) == json_dict

--- a/beartype_test/a00_unit/a40_api/loadbearing/test_api_loadbearing_pydantic.py
+++ b/beartype_test/a00_unit/a40_api/loadbearing/test_api_loadbearing_pydantic.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# --------------------( LICENSE                            )--------------------
+# Copyright (c) 2014-2026 Beartype authors.
+# See "LICENSE" for further details.
+
+'''
+**Beartype load-bearing Pydantic differential unit tests.**
+
+This submodule differentially tests the public
+:func:`beartype.loadbearing.to_json_schema` translator against the third-party
+:mod:`pydantic` package -- the de facto oracle for translating type-hinted
+dataclasses into JSON Schemas. Both translators are run against the same
+dataclasses; their schemas are then compared modulo *dialect* (i.e., stylistic
+schema differences carrying no validation semantics).
+
+Dialect normalized away before comparison:
+
+* Pydantic deduplicates nested dataclass and enumeration subschemas via
+  ``"$defs"``-referencing ``"$ref"`` entries; this proof-of-concept inlines.
+* Pydantic decorates each property with a ``"title"`` derived from the field
+  name, each defaulted property with a ``"default"``, and each documented
+  dataclass with a ``"description"`` derived from its docstring; ours does
+  none of these. (Deriving ``"description"`` from docstrings is a feature
+  this proof-of-concept should arguably steal.)
+* Pydantic accompanies homogeneous ``"const"`` and ``"enum"`` schemas with a
+  redundant ``"type"``; ours does not.
+* ``"anyOf"`` member ordering and ``"required"`` ordering are unspecified.
+
+These tests are skipped when :mod:`pydantic` is *not* installed. Pydantic is
+an explicitly declared *optional* test-time dependency of this project (see
+the ``ml : pydantic`` section of ``pyproject.toml``): full test environments
+(e.g., tox) exercise these tests, while leaner environments lacking pydantic
+silently skip them.
+'''
+
+# ....................{ IMPORTS                            }....................
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# WARNING: To raise human-readable test errors, avoid importing from
+# package-specific submodules at module scope.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+from beartype_test._util.mark.pytskip import skip_unless_package
+
+# ....................{ PRIVATE ~ normalizers              }....................
+def _normalize_schema(schema: dict) -> object:
+    '''
+    Normalize the passed JSON Schema into a dialect-free schema suitable for
+    semantic comparison, resolving all ``"$ref"`` references against the
+    top-level ``"$defs"`` of this schema *and* discarding all dialect noted in
+    the module docstring above.
+    '''
+
+    # Top-level "$defs" against which "$ref" entries are resolved.
+    defs = schema.get('$defs', {})
+
+    def _normalize(value: object) -> object:
+        '''
+        Recursively normalize the passed JSON Schema component.
+        '''
+
+        # If this component is a dictionary...
+        if isinstance(value, dict):
+            # If this component is a reference, resolve this reference against
+            # the top-level "$defs" and normalize the referent instead.
+            if '$ref' in value:
+                ref_name = value['$ref'].removeprefix('#/$defs/')
+                return _normalize(defs[ref_name])
+            # Else, this component is *NOT* a reference.
+
+            # This component, stripped of all dialect.
+            value_normal = {}
+
+            # For each key-value pair of this component...
+            for schema_key, schema_value in value.items():
+                # Silently discard dialect-only keys.
+                if schema_key in ('$defs', 'title', 'default', 'description'):
+                    continue
+                # Silently discard the redundant "type" accompanying "const"
+                # and "enum" schemas.
+                elif schema_key == 'type' and (
+                    'const' in value or 'enum' in value):
+                    continue
+                # Sort "required" field names, whose ordering is unspecified.
+                elif schema_key == 'required':
+                    value_normal[schema_key] = sorted(schema_value)
+                # Sort "anyOf" members (canonically, by repr), whose ordering
+                # is unspecified.
+                elif schema_key == 'anyOf':
+                    value_normal[schema_key] = sorted(
+                        (_normalize(any_of) for any_of in schema_value),
+                        key=repr,
+                    )
+                # Else, recursively normalize this value.
+                else:
+                    value_normal[schema_key] = _normalize(schema_value)
+
+            # Return this normalized component.
+            return value_normal
+        # Else if this component is a list, normalize each item in order.
+        elif isinstance(value, list):
+            return [_normalize(value_item) for value_item in value]
+        # Else, this component is a scalar. Return this scalar as is.
+
+        return value
+
+    # Return the passed schema, normalized.
+    return _normalize(schema)
+
+# ....................{ TESTS                              }....................
+@skip_unless_package('pydantic')
+def test_to_json_schema_vs_pydantic() -> None:
+    '''
+    Differentially test the :func:`beartype.loadbearing.to_json_schema`
+    translator against :class:`pydantic.TypeAdapter` over the full currently
+    supported hint subset, asserting semantic schema equality modulo dialect.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import to_json_schema
+    from dataclasses import (
+        dataclass,
+        field,
+    )
+    from enum import Enum
+    from pydantic import TypeAdapter
+    from typing import (
+        Any,
+        Literal,
+        Optional,
+        Union,
+    )
+
+    class OSaturn(Enum):
+        '''
+        Arbitrary enumeration whose member values are all JSON-encodable.
+        '''
+
+        COME_AWAY = 'come away'
+        GIVE_AN_EAR = 'give an ear'
+
+    @dataclass
+    class ThyThunder:
+        '''
+        Arbitrary nested dataclass.
+        '''
+
+        conscious_of_the_new_command: str
+        rumbles_reluctant: int = 0
+
+    @dataclass
+    class OThouShaltFind:
+        '''
+        Arbitrary dataclass exercising the full currently supported hint
+        subset.
+        '''
+
+        # Scalars.
+        unruffled: str
+        of_all_hoarse_throated: int
+        thine_eagles: float
+        gloam: bool
+
+        # Unions, literals, enumerations, "Any".
+        thy_sharp_lightning: Optional[float]
+        in_unpractised_hands: Union[int, str]
+        scorches_and_burns: Literal['our once serene domain']
+        o_aching_time: Literal['moments big as years', 'a palpable ache', 4]
+        press_upon: OSaturn
+        and_all: Any
+
+        # Containers.
+        those_green_robed_senators: list[int]
+        of_mighty_woods: dict[str, bool]
+        tall_oaks: tuple[str, int]
+        branch_charmed: tuple[float, ...]
+        by_the_earnest_stars: set[str]
+
+        # Nested dataclass.
+        dream_and_so_dream: ThyThunder
+
+        # Defaulted fields, omitted from "required".
+        all_night: bool = False
+        without_a_stir: list[str] = field(default_factory=list)
+
+    # For each dataclass under test...
+    for datacls in (ThyThunder, OThouShaltFind):
+        # Assert that both translators produce semantically equal schemas.
+        assert (
+            _normalize_schema(to_json_schema(datacls)) ==
+            _normalize_schema(TypeAdapter(datacls).json_schema())
+        ), f'Schema divergence from Pydantic for {repr(datacls)}.'
+
+
+@skip_unless_package('pydantic')
+def test_from_json_vs_pydantic() -> None:
+    '''
+    Differentially test the :func:`beartype.loadbearing.from_json`
+    deserializer against :class:`pydantic.TypeAdapter` in strict mode,
+    asserting both deserializers construct equal instances from equal input.
+    '''
+
+    # Defer test-specific imports.
+    from beartype.loadbearing import from_json
+    from dataclasses import dataclass
+    from pydantic import TypeAdapter
+    from typing import Optional
+
+    @dataclass
+    class HeavensAndEarth:
+        are_manifest: str
+        then_thou_first_born: Optional[int]
+        of_all_shaped: float = 0.0
+
+    # JSON-encodable dictionary well-formed under this dataclass.
+    json_dict = {
+        'are_manifest': 'and palpable god',
+        'then_thou_first_born': 33,
+    }
+
+    # Assert both deserializers construct equal instances. Note that Pydantic
+    # is validated in its default lax mode: Pydantic's strict mode rejects
+    # dictionary input for dataclasses outright (requiring preconstructed
+    # instances), rendering it incomparable to from_json(). Lax mode instead
+    # coerces where from_json() rejects; this smoke comparison thus only
+    # exercises already well-typed input, where both policies coincide.
+    assert from_json(HeavensAndEarth, json_dict) == (
+        TypeAdapter(HeavensAndEarth).validate_python(json_dict))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,14 @@ test-tox = [
     # requires Pydantic.
     "fastmcp; python_version < '3.15.0'",
 
+    #FIXME: Re-enable Python >= 3.15 support *AFTER* explicitly supported.
+    # Required by the optional "beartype.loadbearing" Pydantic differential
+    # tests, which treat Pydantic's JSON Schema generation as an oracle. Note
+    # that pydantic is currently *ALSO* a transitive dependency of both
+    # "fastmcp" above and "pandera" further above; this explicit declaration
+    # exists so those tests survive the removal of either.
+    "pydantic; python_version < '3.15.0'",
+
     #FIXME: Actually, let's *NOT* install "pyarrow". "pyarrow" is super-intense,
     #because Apache Arrow is super-intense. Since nothing in @beartype requires
     #"pyarrow", let's tamp down on all this bare-knuckle intensity for now.


### PR DESCRIPTION
So there was [this thing that felt like something between a daydeam and an invitation](https://github.com/beartype/pytest-beartype/pull/33#issuecomment-5435983431) <sup>_which sounds like a Prince lyric_</sup> that opined whether plain type-hinted dataclasses could grow JSON Schema and marshalling superpowers via beartype.

At least that's what I came to realize after having Fabio explain it to me. That was right before he wrote pretty much all of this PR with a few gentle nudges <sup>_in the form of basic questions_</sup> from me.

What follows is mostly Fabio's, edited to compensate for his innate proclivities to periodically remind the reader of his semicolon-laden mechanical roots: an astounding command of language which is somehow devoid of anything resembling culture. (No offense, Fabio, buddy. You're killing it.)

_UPDATE: Busted tests should be addressed by #678._

---

This PR is a deliberately minimal proof-of-concept answering:
*probably, and DOOR is most of the reason why.* [It includes t]hree
commits[]:

1. **`to_json_schema()`** — a recursive walk over public
   `beartype.door` `TypeHint` trees emitting draft 2020-12 JSON
   Schemas.
2. **`to_json()` / `from_json()`** — structural serialization out,
   strict (coercion-free) deserialization in, with
   `die_if_unbearable()` as the final authority on well-typedness in
   *both* directions.

   _[He needed a nudge, but I think he's quite pleased with the
   result. --Ed.]_
3. **Differential tests against Pydantic** — `TypeAdapter` as oracle,
   compared modulo dialect. (Adds `pydantic` to the `test-tox` extra;
   it was already present transitively via `fastmcp`/`pandera`, but an
   oracle should be present on purpose. Tests skip gracefully where
   it's absent.)

   _[I have no idea what the first sentence fragment means, but I'm
   pretty sure the thrust of the third commit is to ask, "What would
   Pydantic do?" and then make sure we do something similar. --Ed.]_

### Supported subset (everything else raises `NotImplementedError`, loudly)

[Supported field types:] Scalars, `Any`, `Optional`/`Union`, `Literal`
(str/int/bool/None), scalar- valued `Enum`s,
`list`/`set`/`frozenset`/`dict[str, T]`, both tuple flavors, nested
non-recursive dataclasses. This covers the bulk of real LLM
tool-calling shapes while dodging every hard question on purpose.

### ~Headline result~ _[ :point_left:  We're not doing that. --Ed.]_

Over that entire subset, our schemas are **semantically identical to
Pydantic's**[. E]very difference is dialect (`$defs`/`$ref` vs
inlining, `title`/`default`/`description` decoration, redundant `type`
beside `const`/`enum`, unspecified orderings), all enumerated and
normalized in the differential test. ~350 lines of DOOR walk reproduce
the oracle on the subset that matters.

_[Why am I suddenly reminded of Hal Incandenza's university admissions
interview in_ Infinite Jest _? --Ed.]_

### DOOR substrate findings (the part [Fabio thinks] you'll actually care about)

* `TupleFixedTypeHint`/`TupleVariableTypeHint` are runtime-importable
  from `beartype.door` but missing from its explicit exports — mypy
  objects. `# type: ignore` + FIXME at the import sites; the upstream
  fix is a one-liner.
* `TypeHint.__iter__` is annotated `Iterable` rather than `Iterator`,
  so mypy rejects iterating a hint. Worked around by recursing via
  `.args` + `TypeHint(arg)` (arguably cleaner anyway).
* Otherwise DOOR held: subclass dispatch + `.args`/`.hint` covered the
  whole subset with zero private-API reaching. The PoC resolves hints
  via `typing.get_type_hints()`[. T]he real implementation should
  presumably use beartype's own resolution machinery instead.

### Policy decisions (hard-coded and documented, awaiting your taste)

* **`to_json()` fails loudly on hint-violating fields** (attribute
  mutation is unchecked, so latent violations are real). Rationale:
  serialization and deserialization are typically far apart[. A]
  silently serialized violation surfaces at some distant consumer
  where the source is untraceable. Alternatives (serialize faithfully;
  warn-and-emit à la Pydantic) are documented in-code as an open
  question.
* `from_json()` is strict on values, lax on shape — no coercion
  (including no bool-as-int), except int→float per JSON's numeric
  indifference[. U]nknown keys ignored. Notably this position has *no*
  Pydantic equivalent[. T]heir strict mode rejects dict input for
  dataclasses outright.
* Defaults ⇒ optional; `additionalProperties` left unset; nested
  dataclasses inlined (recursion raises rather than `$defs`/`$ref`,
  for now).
* Public signatures use the stub-only `_typeshed.DataclassInstance`
  protocol under `TYPE_CHECKING`. The beartype-native alternative —
  `beartype.vale` validators plus `@beartype`-decorating the API
  itself — is noted as a taste question for you.

### Deliberately not here (yet)

* The `loadbearing` attachment to `@beartype` itself — these are
  module functions; the decorator-attached namespace is sugar for a
  later commit, designed under your eye.
* `to_gbnf()` — the honest version chains our schemas through
  llama.cpp's `json_schema_to_grammar.py` rather than writing a
  grammar compiler; demoable next.

  _[Not sure if that means we have a dishonest version now, but I've
  found LLMs_ **love** _to talk about honesty, especially theirs.
  There's a line from MacBeth that might be apropos. --Ed.]_
* Stolen-from-Pydantic nicety worth adding: `description` derived from
  the dataclass docstring (the differential tests found this one).
* A survey of prior art (apischema, msgspec, cattrs)[. T]he sharper
  pitch isn't that schema-from-dataclass is novel (it isn't), but that
  beartype already owns the hard parts: hint resolution, DOOR, and the
  validator.

🤖 Generated with [omitted]  _[ :point_left:  Yeah, we're not doing that, either. --Ed.]_