### PR TITLE
Handle the bare UnionType class in get_hint_pep_childs

### DIFF
--- a/beartype/_util/hint/pep/utilpepget.py
+++ b/beartype/_util/hint/pep/utilpepget.py
@@ -46,6 +46,7 @@ from beartype._util.hint.pep.proposal.pep585 import (
 )
 from beartype._util.hint.pep.proposal.pep646.pep646692unpack import (
     make_hint_pep646_typevartuple_unpacked_subbed)
+from types import UnionType
 from typing import (
     Any,
     Optional,
@@ -158,7 +159,16 @@ def get_hint_pep_childs(hint: object) -> tuple:
         # valid hints, this "__args__" implementation is *TECHNICALLY* also
         # valid albeit semantically meaningless. In this case, simply return the
         # empty tuple.
-        if hint is Union:
+        #
+        # Likewise, if this hint is the unsubscripted "types.UnionType" class
+        # itself (as opposed to an actual PEP 604-compliant union instance
+        # like "int | str"), this hint's "__args__" dunder attribute is
+        # merely the unbound slot descriptor inherited from the class, not an
+        # actual tuple of child hints. This arises whenever a caller passes
+        # "type(some_union)" or "UnionType" itself as a hint (e.g., inside a
+        # "type[...]" hint). As with the "Union" case above, return the empty
+        # tuple rather than erroring out.
+        if hint is Union or hint is UnionType:
             return ()
         # Else, this hint is *NOT* the unsubscripted "typing.Union" hint. In
         # this case, raise an exception.

--- a/beartype_test/a00_unit/a40_api/door/_fixture/_doorfix_is_subhint.py
+++ b/beartype_test/a00_unit/a40_api/door/_fixture/_doorfix_is_subhint.py
@@ -107,6 +107,7 @@ def door_cases_is_subhint() -> 'Iterable[Tuple[object, object, bool]]':
         TypedDict,
         Union,
     )
+    from types import UnionType
 
     # ..................{ NEWTYPES                           }..................
     NewStr = NewType('NewStr', str)
@@ -339,6 +340,17 @@ def door_cases_is_subhint() -> 'Iterable[Tuple[object, object, bool]]':
         (Union[str, list], Union[str, int], False),
         (Union[int, str, list], list, False),
         (Union[int, str, list], Union[int, str], False),
+
+        # PEP 604-compliant "int | str" new-style unions instantiate the
+        # low-level C-based "types.UnionType" class. Passing either that
+        # class itself (rather than an instance of it) or a "type[...]" hint
+        # wrapping that class used to raise an unexpected
+        # "BeartypeDecorHintPepException", because the class' inherited
+        # "__args__" dunder attribute is an unbound slot descriptor rather
+        # than an actual tuple of child hints. See also the "typing.Union"
+        # cases above.
+        (type(int | str), type[Union], False),
+        (type[int | str], type[UnionType], False),
 
         # ..................{ PEP (484|585) ~ callable       }..................
         # PEP 484-compliant callable type hints.


### PR DESCRIPTION
Fixes #609.

`is_subhint(type(int | str), type[Union])` and similar calls crash with a `BeartypeDecorHintPepException` on Python < 3.14. The root cause is in `get_hint_pep_childs()`: when the bare `types.UnionType` class itself turns up as a hint (rather than an actual PEP 604 union instance like `int | str`), reading its `__args__` gets you the class's inherited unbound slot descriptor instead of a real tuple, and the function raises.

There's already a special case right above this one handling the exact same shape of problem for bare `typing.Union` on Python 3.14+, where `Union` became a C-based type with the same kind of non-tuple `__args__`. I just extended that same check to also cover `types.UnionType`, so the bare class is treated as having no children rather than blowing up.

Added two cases to the `is_subhint` fixture covering both the `type(int | str)` and `type[int | str]` shapes from the issue. Confirmed both crash on the unpatched code and pass with the fix (via `git stash`). Ran the full local suite: 422 passed, 41 skipped (all skips are pre-existing, due to optional dependencies not installed here, like numpy/torch/pandas).